### PR TITLE
Fix a typo on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
         <div class="seven columns offset-by-one">
           <h3>Brimir, an open source ticket manager</h3>
           <h4 class="subheader">
-            Declutter your support inbox. Provide support with a team of different agents, with a perfect overview of all your communcation.        
+            Declutter your support inbox. Provide support with a team of different agents, with a perfect overview of all your communication.        
           </h4>
         </div>
         <div class="four columns text-center">


### PR DESCRIPTION
There is a typo in the subtitle on the homepage
