### PR TITLE
Verify existence before creating entries on seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,26 +6,26 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-frank = User.new({ email: 'frank@xxxx.com', password: 'testtest', password_confirmation: 'testtest' })
+frank = User.where(email: 'frank@xxxx.com').first_or_create({ email: 'frank@xxxx.com', password: 'testtest', password_confirmation: 'testtest' })
 frank.agent = true
 frank.save!
 
-sem = User.create({ email: 'sem@xxxx.com', password: 'testtest', password_confirmation: 'testtest' })
+sem = User.where(email: 'sem@xxxx.com').first_or_create({ email: 'sem@xxxx.com', password: 'testtest', password_confirmation: 'testtest' })
 sem.agent = true
 sem.save!
 
-Status.create!({ name: 'Deleted' })
-status_closed = Status.create!({ name: 'Closed' })
-status_open = Status.create!({ name: 'Open', default: true })
+Status.where(name: 'Deleted').first_or_create!({ name: 'Deleted' })
+status_closed = Status.where(name: 'Closed').first_or_create!({ name: 'Closed' })
+status_open = Status.where(name: 'Open').first_or_create!({ name: 'Open', default: true })
 
-priority_none = Priority.create!({ name: 'None', default: true })
-priority_low = Priority.create!({ name: 'Low' })
-priority_medium = Priority.create!({ name: 'Medium' })
-priority_high = Priority.create!({ name: 'High' })
+priority_none = Priority.where(name: 'None').first_or_create!({ name: 'None', default: true })
+priority_low = Priority.where(name: 'Low').first_or_create!({ name: 'Low' })
+priority_medium = Priority.where(name: 'Medium').first_or_create!({ name: 'Medium' })
+priority_high = Priority.where(name: 'High').first_or_create!({ name: 'High' })
 
 password_length = 12
 password = Devise.friendly_token.first(password_length)
-owner = User.create!(email: 'test@xxxx.com', password: password, password_confirmation: password)
+owner = User.where(email: 'test@xxxx.com').first_or_create!({ email: 'test@xxxx.com', password: password, password_confirmation: password })
 
 Ticket.create!([
   { 


### PR DESCRIPTION
Use first_or_create to avoid duplicated entries when executing seeds.rb more than once.
