### PR TITLE
strip, not trim

### DIFF
--- a/db/migrate/20140815125817_create_notifications.rb
+++ b/db/migrate/20140815125817_create_notifications.rb
@@ -18,7 +18,7 @@ class CreateNotifications < ActiveRecord::Migration
       addresses += reply.bcc.to_s.split(',')
 
       addresses.each do |address|
-        u = User.where(email: address.trim).first_or_initialize
+        u = User.where(email: address.strip).first_or_initialize
 
         if u.new_record?
           password_length = 12


### PR DESCRIPTION
```
[root@meow brimir]# RAILS_ENV=production rake db:migrate
== 20140815125817 CreateNotifications: migrating ==============================
-- create_table(:notifications)
   -> 0.0130s
-- add_index(:notifications, [:notifiable_id, :notifiable_type, :user_id], {:unique=>true, :name=>:unique_notification})
   -> 0.0033s
rake aborted!
StandardError: An error has occurred, all later migrations canceled:

undefined method `trim' for "my@email.com":String/www/xxxxxx/apps/brimir/db/migrate/20140815125817_create_notifications.rb:21:in `block (2 levels) in change'
```
