### PR TITLE
Adding User Avatars (supporting external api and gravatar)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,6 @@ gem 'timecop'
 
 # fancybox for showing image in lightbox
 gem 'fancybox2-rails', '~> 0.2.8'
+
+# gravatar for user avatar images
+gem 'gravatar_image_tag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
       tzinfo (~> 1.2, >= 1.2.2)
     globalid (0.3.0)
       activesupport (>= 4.1.0)
+    gravatar_image_tag (1.2.0)
     hashie (3.3.2)
     hike (1.2.3)
     http_accept_language (2.0.5)
@@ -265,6 +266,7 @@ DEPENDENCIES
   font-awesome-rails (~> 4.0)
   foundation-rails (~> 5.5.0)
   foundation_rails_helper
+  gravatar_image_tag
   http_accept_language
   jbuilder (~> 2.2)
   jquery-rails

--- a/app/assets/stylesheets/application-print.scss
+++ b/app/assets/stylesheets/application-print.scss
@@ -129,3 +129,7 @@ h5{
 		padding: 0;
 	}
 }
+
+.user-avatar{
+  display: none;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -86,6 +86,19 @@ td.priority-high{ border-left: 3px solid #da1500; color: #626262; }
 
 .text-secondary{ color: #999 !important; }
 
+@mixin vendor($property, $value...){
+    -webkit-#{$property}: $value;
+       -moz-#{$property}: $value;
+        -ms-#{$property}: $value;
+         -o-#{$property}: $value;
+            #{$property}: $value;
+}
+
+@mixin radius(){
+  @include vendor("border-radius", 5px);
+}
+
+
 /* --- Side menu --- */
 
 aside{
@@ -318,4 +331,17 @@ ul.off-canvas-list li:hover > a{
 .joyride-expose-wrapper{
 	box-shadow: none;
 	background: none;
+}
+
+.user-avatar{
+  @include radius();
+  margin-right: 5px;
+}
+
+.avatar-left{
+  float: left;
+}
+
+.avatar-matter{
+  overflow: hidden;
 }

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -84,7 +84,7 @@ module AvatarHelper
   # 
   def user_avatar(user, options = {size: 24})
     @user_avatar ||= {}
-    @user_avatar[[user.id, options]] ||= user_avatar_from_api(user, options) || user_gravatar(user, options) if AppSettings.display_user_avatars
+    @user_avatar[[user.id, options]] ||= user_avatar_from_api(user, options) || user_gravatar(user, options) if display_user_avatars?
   end
   
   # Display the user avatar if `AppSetting.display_user_avatars` is `true`.
@@ -92,6 +92,10 @@ module AvatarHelper
   #
   def user_avatar_or_fa_user_icon(user)
     user_avatar(user) || content_tag(:i, nil, class: 'fa fa-user')
+  end
+  
+  def display_user_avatars?
+    AppSettings.display_user_avatars
   end
   
   private

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -1,0 +1,124 @@
+# # Generating User Avatars
+#
+# This feature adds optional user avatars to email addresses
+# displayed in the application.
+#
+# The avatars are fetched using the gravatar service, which can
+# be found at http://gravatar.com.
+# 
+# The gem *gravatar_image_tag* is used:
+# https://github.com/mdeering/gravatar_image_tag
+# 
+# ## Global Settings
+# 
+# Global settings can be configured in the `config/settings.yml` file.
+# 
+#   * `display_user_avatars`: `true`, `false`
+#       Whether to use the avatar feature.
+#       Default: `false`
+#
+#   * `default_user_avatar`: url or gravatar default setting
+#       The avatar that is shown when no avatar can be determined
+#       for an email address.
+#       Default: `'identicon'`
+# 
+#       Possible settings:
+#         - any image url,
+#           for example, this github icon url:
+#           "https://assets.github.com/images/gravatars/gravatar-140.png"
+#         - `"mm"`: (mystery-man)
+#           a simple, cartoon-style silhouetted outline of a person
+#         - `"identicon"`:
+#           a geometric pattern based on an email hash
+#         - `"monsterid"`:
+#           a generated 'monster' with different colors, faces, etc
+#         - `"wavatar"`:
+#           generated faces with differing features and backgrounds
+#         - `"retro"`:
+#           awesome generated, 8-bit arcade-style pixelated faces
+#         - `"blank"`:
+#           a transparent PNG image
+# 
+#         See also: https://gravatar.com/site/implement/images/
+# 
+# ## Usage
+# 
+# In the views, you can insert the avatar image tag of a `user` inline:
+# 
+#     <%= user_avatar(user) %>
+# 
+# In order to adjust an avatar left of some content, you may use these
+# pre-defined css classes:
+# 
+#    <div class="avatar-left"><%= user_avatar(user) %></div>
+#    <div class="avatar-matter">
+#      Other Content
+#      For example, an email of the user.
+#    </div>
+#
+module AvatarHelper
+  
+  # Generates a user avatar image tag if `display_user_avatars`
+  # is set to true in `conifg/settings.yml`.
+  #
+  # Options:
+  #   - size
+  #   - (see gravatar_default_options)
+  # 
+  def user_avatar(user, options = {})
+    @user_avatar ||= {}
+    @user_avatar[[user.id, options]] ||= user_gravatar(user, options) if AppSettings.display_user_avatars
+  end
+  
+  # Display the user avatar if `AppSetting.display_user_avatars` is `true`.
+  # Otherwise, display `<i class="fa fa-user"></i>`.
+  #
+  def user_avatar_or_fa_user_icon(user)
+    user_avatar(user) || content_tag(:i, class: 'fa fa-user')
+  end
+  
+  private
+
+  def user_gravatar(user, options = {})
+    options[:gravatar] ||= {}
+    options[:gravatar][:size] ||= options[:size] if options[:size]
+    gravatar_image_tag(user.email, gravatar_default_options.deep_merge(options))
+  end
+  
+  def gravatar_default_options
+    {
+      :gravatar => {
+        :size => 24,
+        :secure => true,
+        :default => default_avatar_url
+      },
+      :class => 'user-avatar'
+    }
+  end
+  
+  # This sets the default gravatar image.
+  # 
+  # Possible values are:
+  #   - any image url,
+  #     for example, this github icon url:
+  #     "https://assets.github.com/images/gravatars/gravatar-140.png"
+  #   - "mm":
+  #     (mystery-man) a simple, cartoon-style silhouetted outline of a person
+  #   - "identicon":
+  #     a geometric pattern based on an email hash
+  #   - "monsterid":
+  #     a generated 'monster' with different colors, faces, etc
+  #   - "wavatar":
+  #     generated faces with differing features and backgrounds
+  #   - "retro":
+  #     awesome generated, 8-bit arcade-style pixelated faces
+  #   - "blank":
+  #     a transparent PNG image
+  #
+  # See also: https://gravatar.com/site/implement/images/
+  # 
+  def default_avatar_url
+    AppSettings.default_user_avatar || 'identicon'
+  end
+  
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
                 <li id="joyride-users"><a href="<%= users_path %>"><i class="fa fa-users fa-fw"></i></a></li>
             <% end %>
             <li class="has-dropdown" id="joyride-settings">
-              <a href="#"><%= current_user.email %></a>
+              <a href="#"><%= user_avatar(current_user) %><%= current_user.email %></a>
               <ul class="dropdown">
                 <li>
                   <%= link_to edit_user_path(current_user) do %>

--- a/app/views/replies/_form.html.erb
+++ b/app/views/replies/_form.html.erb
@@ -3,28 +3,32 @@
   <%= r.hidden_field :ticket_id %>
   <div class="ma">
     <h3><%= t(:reply) %></h3>
+    
+    <div class="avatar-left"><%= user_avatar(current_user) %></div>
+    <div class="avatar-matter">
 
-    <%
-      content = '<p></p>' + current_user.signature.to_s
-      reply_to = @reply.other_replies.order(:id).last
-
-      if reply_to.nil?
-        reply_to = @reply.ticket
-      end
-
-      content += '<br />'
-      content += t(:on_date_author_wrote, author: reply_to.user.email,
-          date: l(reply_to.created_at.in_time_zone(current_user.time_zone), format: :long))
-      content += '<br />' + text_to_html(wrap_and_quote(reply_to.content))
-    %>
-
-
-    <p>
-      <%= r.text_area :content, label: false, class: 'tinymce',
-          value: (@reply.content.nil? ? content : @reply.content) %>
-    </p>
-
-    <%= render 'attachments/form', f: r %>
+      <%
+        content = '<p></p>' + current_user.signature.to_s
+        reply_to = @reply.other_replies.order(:id).last
+      
+        if reply_to.nil?
+          reply_to = @reply.ticket
+        end
+      
+        content += '<br />'
+        content += t(:on_date_author_wrote, author: reply_to.user.email,
+            date: l(reply_to.created_at.in_time_zone(current_user.time_zone), format: :long))
+        content += '<br />' + text_to_html(wrap_and_quote(reply_to.content))
+      %>
+      
+      
+      <p>
+        <%= r.text_area :content, label: false, class: 'tinymce',
+            value: (@reply.content.nil? ? content : @reply.content) %>
+      </p>
+      
+      <%= render 'attachments/form', f: r %>
+    </div>
 
     <p class="no-m">
       <%= t(:notification_will_be_sent_to) %>

--- a/app/views/replies/_reply.html.erb
+++ b/app/views/replies/_reply.html.erb
@@ -1,36 +1,39 @@
 <li class="reply radius mb">
-  <p class="no-m">
-    <strong><%= reply.user.email %></strong>
-    <small class="pull-right"><%= time_ago_in_words(reply.created_at.in_time_zone(current_user.time_zone)) %> <%= t(:ago) %></small>
-  </p>
-  <div id="reply-<%=reply.id%>" class="<%= div_class %>">
-
-    <% if reply.content_type == 'html' %>
-      <% content = reply.content %>
-    <% else %>
-      <% content = text_to_html(reply.content) %>
-    <% end %>
-
-    <%= sanitize_html(content) %>
-
-    <% if reply.attachments.size > 0 %>
-      <hr />
-      <ul class="attachments">
-        <%= render reply.attachments %>
-      </ul>
-    <% end %>
-
-    <hr />
+  <div class="avatar-left"><%= user_avatar(reply.user) %></div>
+  <div class="avatar-matter">
     <p class="no-m">
-      <% if reply.notified_users.count > 0 %>
-        <%= t(:notification_sent_to) %>    
-        <% reply.notified_users.each do |user| %>
-          <%= user.email %>
-        <% end %>
-      <% else %>
-        <%= t(:no_notifications_sent) %>
-      <% end %>
+      <strong><%= reply.user.email %></strong>
+      <small class="pull-right"><%= time_ago_in_words(reply.created_at.in_time_zone(current_user.time_zone)) %> <%= t(:ago) %></small>
     </p>
-
+    <div id="reply-<%=reply.id%>" class="<%= div_class %>">
+    
+      <% if reply.content_type == 'html' %>
+        <% content = reply.content %>
+      <% else %>
+        <% content = text_to_html(reply.content) %>
+      <% end %>
+    
+      <%= sanitize_html(content) %>
+    
+      <% if reply.attachments.size > 0 %>
+        <hr />
+        <ul class="attachments">
+          <%= render reply.attachments %>
+        </ul>
+      <% end %>
+    
+      <hr />
+      <p class="no-m">
+        <% if reply.notified_users.count > 0 %>
+          <%= t(:notification_sent_to) %>    
+          <% reply.notified_users.each do |user| %>
+            <%= user.email %>
+          <% end %>
+        <% else %>
+          <%= t(:no_notifications_sent) %>
+        <% end %>
+      </p>
+    
+    </div>
   </div>
 </li>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -45,16 +45,20 @@
       <tr data-ticket-url="<%= ticket_url(ticket) %>">
 
         <td class="priority-<%= ticket.priority %> table-nowrap">
-          <span class="block"><%= ticket.user.email %></span>
-          <% unless ticket.subject.blank? %>
-            <a href="<%= ticket_url(ticket) %>">
-              <strong><%= ticket.subject %></strong>
-            </a>
-          <% else %>
-            <%= link_to ticket do %>
-              <em><%= t(:no_subject) %></em>
+          <div class="avatar-left"><%= user_avatar(ticket.user) %></div>
+          <div class="avatar-matter">
+            <span class="block"><%= ticket.user.email %></span>
+            <% unless ticket.subject.blank? %>
+              <a href="<%= ticket_url(ticket) %>">
+                <strong><%= ticket.subject %></strong>
+              </a>
+            <% else %>
+              <%= link_to ticket do %>
+                <em><%= t(:no_subject) %></em>
+              <% end %>
             <% end %>
-          <% end %>
+            <br />Test
+          </div>
         </td>
 
         <td>
@@ -72,13 +76,14 @@
           <span class="block"><%= l ticket.created_at.in_time_zone(current_user.time_zone), format: :short %></span>
           <% if can? :update, ticket %>
             <% if ticket.assignee %>
-              <a data-assignee-id="<%= ticket.assignee.id %>" href="#"><i class="fa fa-user"></i> <%= ticket.assignee.email %></a>
+              <a data-assignee-id="<%= ticket.assignee.id %>" href="#"><%= user_avatar_or_fa_user_icon(ticket.assignee) %> <%= ticket.assignee.email %></a>
             <% else %>
               <a data-assignee-id="" href="#"><em><%= t(:unassigned) %></em></a>
             <% end %>
           <% else %>
             <% if ticket.assignee %>
-              <i class="fa fa-user"></i> <%= ticket.assignee.email %>
+              <%= user_avatar_or_fa_user_icon(ticket.assignee) %>
+              <%= ticket.assignee.email %>
             <% else %>
               <em><%= t(:unassigned) %></em>
             <% end %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -14,35 +14,39 @@
 <div class="row collapse">
   <div class="medium-9 columns br">
     <div class="ma">
-      <% if @ticket.content.blank? %>
-        (<%= t(:no_content) %>)
-      <% else %>
-
-        <div class="output">
-          <% if @ticket.content_type == 'html' %>
-            <% content = @ticket.content %>
-          <% else %>
-            <% content = text_to_html(@ticket.content) %>
-          <% end %>
-
-          <%= sanitize_html(content) %>
-        </div>
-      <% end %>
-
-      <ul class="inline-list text-secondary">
-        <li><%= t(:notification_sent_to) %></li>
-        <% @ticket.notified_users.each do |user| %>
-          <li><%= user.email %></li>
+      <div class="avatar-left"><%= user_avatar(@ticket.user) %></div>
+      <div class="avatar-matter">
+      
+        <% if @ticket.content.blank? %>
+          (<%= t(:no_content) %>)
+        <% else %>
+        
+          <div class="output">
+            <% if @ticket.content_type == 'html' %>
+              <% content = @ticket.content %>
+            <% else %>
+              <% content = text_to_html(@ticket.content) %>
+            <% end %>
+        
+            <%= sanitize_html(content) %>
+          </div>
         <% end %>
-      </ul>
-
-
-      <% if @ticket.attachments.size > 0 %>
-        <hr />
-        <ul class="attachments">
-          <%= render @ticket.attachments %>
+        
+        <ul class="inline-list text-secondary">
+          <li><%= t(:notification_sent_to) %></li>
+          <% @ticket.notified_users.each do |user| %>
+            <li><%= user.email %></li>
+          <% end %>
         </ul>
-      <% end %>
+        
+        
+        <% if @ticket.attachments.size > 0 %>
+          <hr />
+          <ul class="attachments">
+            <%= render @ticket.attachments %>
+          </ul>
+        <% end %>
+      </div>
     </div>
 
     <% if @ticket.replies.size > 1 %>
@@ -123,7 +127,7 @@
                 <span class="fa fa-fw fa-user"></span>
                 <%= t(:unassigned) %>
               <% else %>
-                <span class="fa fa-fw fa-user"></span>
+                <%= user_avatar_or_fa_user_icon(@ticket.assignee) %>
                 <%= @ticket.assignee.email %>
               <% end %>
             </a>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -16,6 +16,13 @@
     <div class="ma">
       <div class="avatar-left"><%= user_avatar(@ticket.user) %></div>
       <div class="avatar-matter">
+        
+        <% if display_user_avatars? # Redundant, but is more intuitive. %>
+          <p>
+            <strong><%= @ticket.user.email %></strong><br />
+            <%= @ticket.subject %>
+          </p>
+        <% end %>
       
         <% if @ticket.content.blank? %>
           (<%= t(:no_content) %>)

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -2,6 +2,8 @@
     <div class="row mt mb">
 
       <div class="medium-6 columns">
+        
+        <%= user_avatar(@user, size: 64) %>
 
         <h5><%= t(:account_settings) %></h5>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -21,7 +21,10 @@
       <tbody>
         <% @users.each do |user| %>
           <tr>
-            <td><%= link_to user.email, edit_user_path(user) %></td>
+            <td>
+              <%= user_avatar(user) %>
+              <%= link_to user.email, edit_user_path(user) %>
+            </td>
             <td><%= (user.agent?) ? t(:agent) : t(:customer) %></td>
           </tr>
         <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,7 @@ default: &defaults
   ignore_user_agent_locale: false
   display_user_avatars: false
   default_user_avatar: 'identicon'
+  user_avatar_api_url: ''
 
 development:
   <<: *defaults

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,7 @@
 default: &defaults
   ignore_user_agent_locale: false
+  display_user_avatars: false
+  default_user_avatar: 'identicon'
 
 development:
   <<: *defaults


### PR DESCRIPTION
# Adding User Avatars

This feature adds optional user avatars to email addresses
displayed in the application.

The feature is disabled by default and has to be enabled using the
`display_user_avatars` setting in `config/settings.yml`.

The avatars are fetched from an api defined by the 
`user_avatar_api_url` setting.

If `user_avatar_api_url`is unset, the avatars are fetched using 
the gravatar service, which can be found at http://gravatar.com.

The gem *gravatar_image_tag* is used:
https://github.com/mdeering/gravatar_image_tag


## Motivation

* Our agents are used to avatars from our main app.
* The agents recognize users by their avatars. This way, they recall an already-known client more easily. Connecting to the main app via an api, the same avatars are displayed that are already known from the main app.
* The optical separation of replies is more intuitive with avatars: It's harder to miss a reply when scrolling fast. And it looks more like a conversation view.


## Screenshots

### `AppSettings.display_user_avatars == true`

![bildschirmfoto 2015-05-14 um 22 41 40](https://cloud.githubusercontent.com/assets/1679688/7641873/e8e7f328-fa8c-11e4-83d6-d2d45566ebd3.png)

![bildschirmfoto 2015-05-14 um 22 42 23](https://cloud.githubusercontent.com/assets/1679688/7641915/33578d74-fa8d-11e4-8c29-1cf74b14716c.png)

![bildschirmfoto 2015-05-14 um 22 42 54](https://cloud.githubusercontent.com/assets/1679688/7641922/3c1dab82-fa8d-11e4-831f-edf7223f6318.png)

![bildschirmfoto 2015-05-14 um 22 43 07](https://cloud.githubusercontent.com/assets/1679688/7641929/410befdc-fa8d-11e4-9dd9-1e8d6909788e.png)

### `AppSettings.display_user_avatars == false`

![bildschirmfoto 2015-05-14 um 22 44 05](https://cloud.githubusercontent.com/assets/1679688/7641931/4762a7a4-fa8d-11e4-8053-1d507bd6c8ae.png)

![bildschirmfoto 2015-05-14 um 22 44 42](https://cloud.githubusercontent.com/assets/1679688/7641933/4b9d5742-fa8d-11e4-96eb-cc58b5dc436c.png)


## Global Settings

Global settings can be configured in the `config/settings.yml` file.

  * `display_user_avatars`: `true`, `false`
      Whether to use the avatar feature.
      Default: `false`

  * `default_user_avatar`: url or gravatar default setting
      This avatar that is shown when no avatar can be determined for an email address.
      Default: `'identicon'`
      
      Possible settings (see also: https://gravatar.com/site/implement/images/):
       
      - any image url,
          for example, this github icon url:
          "https://assets.github.com/images/gravatars/gravatar-140.png"
      - `"mm"`: (mystery-man)
          a simple, cartoon-style silhouetted outline of a person
      - `"identicon"`:
          a geometric pattern based on an email hash
      - `"monsterid"`:
          a generated 'monster' with different colors, faces, etc
      - `"wavatar"`:
          generated faces with differing features and backgrounds
      - `"retro"`:
          awesome generated, 8-bit arcade-style pixelated faces
      - `"blank"`:
          a transparent PNG image

  * `user_avatar_api_url`: url of an api to fetch the avatar image
       url from.
       
       For example:
       "http://localhost:3000/avatars?email=:email&size=:size"

       The placeholders `:email` and `:size` will be replaced with
       the user's email and the size of the avatar to request.


## Usage

In the views, you can insert the avatar image tag of a `user` inline:

    <%= user_avatar(user) %>

In order to adjust an avatar left of some content, you may use these
pre-defined css classes:

    <div class="avatar-left"><%= user_avatar(user) %></div>
    <div class="avatar-matter">
      Other Content
      For example, an email of the user.
    </div>

In places where the default layout uses `<i class="fa fa-user"></i>`,
use `<%= user_avatar_or_fa_user_icon(user) %>` instead.