### PR TITLE
fixing user avatars for new design when fetching the avatars from api.

### DIFF
--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -113,12 +113,20 @@ module AvatarHelper
         :secure => true,
         :default => default_avatar_url
       },
-      :class => 'user-avatar'
+      :class => 'avatar left mrm'
     }
   end
   
-  def user_avatar_from_api(user, options = {size: 24})
-    image_tag(user_avatar_url_from_api(user, options), width: options[:size], height: options[:size], class: 'user-avatar') if user_avatar_url_from_api(user)
+  def user_avatar_from_api(user, options = {})
+    options = user_avatar_from_api_default_options.deep_merge(options)
+    image_tag(user_avatar_url_from_api(user, options), width: options[:size], height: options[:size], class: options[:class]) if user_avatar_url_from_api(user)
+  end
+  
+  def user_avatar_from_api_default_options
+    {
+      :class => 'avatar left mrm',
+      :size => 24
+    }
   end
   
   def user_avatar_url_from_api(user, options = {})


### PR DESCRIPTION
I've seen that you've updated the design. However the new avatar styles did not work when fetching the avatars from an api.

This is because the css class options has not been used when using the `AvatarHelper#user_avatar_from_api` method. Therefore, avatars have been not styled correctly when fetching avatars through an api.

This commit fixes this problem.

----

Before this commit:

![bildschirmfoto 2015-06-17 um 23 43 04](https://cloud.githubusercontent.com/assets/1679688/8219490/af693e6c-154a-11e5-8ba2-d9002028fe57.png)

After this commit:

![bildschirmfoto 2015-06-17 um 23 43 21](https://cloud.githubusercontent.com/assets/1679688/8219491/b509d78c-154a-11e5-8e17-9d8b21410a28.png)

