### PR TITLE
adding feature: filter by user

### DIFF
--- a/app/assets/stylesheets/_foundation_and_overrides.scss
+++ b/app/assets/stylesheets/_foundation_and_overrides.scss
@@ -76,4 +76,6 @@ $button-border-width: 1px;
 $button-border-style: solid;
 $button-radius: 0;
 
+$sub-nav-active-bg: #67c2e5;
+
 @import 'foundation';

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -59,12 +59,13 @@ class TicketsController < ApplicationController
   def index
     @agents = User.agents
 
-    params[:status] ||= 'open'
+    params[:status] ||= 'open' unless params[:user_id]
 
     @tickets = @tickets.by_status(params[:status])
       .search(params[:q])
       .by_label_id(params[:label_id])
       .filter_by_assignee_id(params[:assignee_id])
+      .filter_by_user_id(params[:user_id])
       .ordered
 
     respond_to do |format|

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -56,7 +56,11 @@ class Ticket < ActiveRecord::Base
   }
 
   scope :by_status, ->(status) {
-    where(status: Ticket.statuses[status.to_sym])
+    if status
+      where(status: Ticket.statuses[status.to_sym])
+    else
+      all
+    end
   }
 
   scope :filter_by_assignee_id, ->(assignee_id) {
@@ -66,6 +70,14 @@ class Ticket < ActiveRecord::Base
       else
         where(assignee_id: assignee_id)
       end
+    else
+      all
+    end
+  }
+  
+  scope :filter_by_user_id, ->(user_id) {
+    if user_id
+      where(user_id: user_id)
     else
       all
     end

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -36,6 +36,15 @@
       <% end %>
     </div>
   </div>
+  <% if params[:user_id] %>
+    <dl class="sub-nav">
+      <dt><%= t :filter %>:</dt>
+      <dd class="active"><%= link_to root_path do %>
+        <%= User.find(params[:user_id]).email %>&nbsp;&nbsp;
+        <i class="fa fa-times-circle fa-fw"></i>
+      <% end %></dd>
+    </dl>
+  <% end %>
 </div>
 
 <section class="tickets">
@@ -68,8 +77,8 @@
               <% end %>
             <% end %>
             <span class="block">
-              <%= t :ticket_id_created_by_at, id: ticket.id, user: ticket.user.email,
-                  at: l(ticket.created_at.in_time_zone(current_user.time_zone), format: :short) %>
+              <%= t(:ticket_id_created_by_at, id: ticket.id, user: link_to(ticket.user.email, user_tickets_path(user_id: ticket.user)),
+                  at: l(ticket.created_at.in_time_zone(current_user.time_zone), format: :short)).html_safe %>
             </span>
             <% if ticket.locked?(current_user) %>
               <em><%= t(:locked_by_user, user: ticket.locked_by.email) %></em>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -19,7 +19,7 @@
           <%= !@ticket.subject.blank? ? @ticket.subject : "<em>(#{t(:no_subject)})</em>".html_safe %>
         </h3>
         <h5 class="text-default mb no-mt">
-          <%= t(:ticket_by_at, email: @ticket.user.email, at: l(@ticket.created_at.in_time_zone(current_user.time_zone), format: :long)) %>
+          <%= t(:ticket_by_at, email: link_to(@ticket.user.email, user_tickets_path(user_id: @ticket.user.id)), at: l(@ticket.created_at.in_time_zone(current_user.time_zone), format: :long)).html_safe %>
           <% unless @ticket.to_email_address.nil? %>
             <%= t :to_email, email: @ticket.to_email_address.email %>
           <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -56,7 +56,12 @@ de:
   unassigned: Nicht zugewiesen
   no_tickets_found: Keine Tickets gefunden.
   search: Suche
+  filter: Filter
   minutes: Minuten
+  are_you_sure_empty_trash: Papierkorb wirklich leeren?
+  locked_by_user: 'Das Ticket wird derzeit von %{user} bearbeitet.'
+  ticket_id_created_by_at: '#%{id} erstellt von %{user} am %{at}'
+  
 
 # tickets/show
   add: Neu

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
   unassigned: Unassigned
   no_tickets_found: No tickets found.
   search: Search
+  filter: Filter
   minutes: minutes
   are_you_sure_empty_trash: Delete all tickets in the trash?
   locked_by_user: Ticket currently being handled by %{user}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Brimir::Application.routes.draw do
 
   devise_for :users, controllers: { omniauth_callbacks: 'omniauth' }
 
-  resources :users
+  resources :users do
+    get :tickets, to: 'tickets#index'
+  end
 
   namespace :tickets do
     resource :deleted, only: :destroy, controller: :deleted


### PR DESCRIPTION
## Overview

This pull request adds a mechanism to quickly list all tickets created by a certain user. 

Also, adding some missing German translations.

## Usage

Clicking on a user’s email address in `tickets#index` or `tickets#show`
leads to `tickets#index` where all tickets by that user are shown.

![bildschirmfoto 2015-09-08 um 18 41 22](https://cloud.githubusercontent.com/assets/1679688/9741471/e19920fe-565a-11e5-86ac-a0ca8e4aed71.png)

This view shows tickets in all states, i.e. also closed tickets, in
order to provide a quick way to look up all tickets by a certain user.

When in this filtered mode, a filter bar is shown in `tickets#index`.
Clicking on the filter entry removes the filter.

![bildschirmfoto 2015-09-08 um 18 41 42](https://cloud.githubusercontent.com/assets/1679688/9741484/e88a941a-565a-11e5-949e-bcf5958c78c4.png)