### PR TITLE
New feature: Include conversation in reply emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'byebug', group: [:development, :test]
 group :development do
   # Spring application pre-loader
   gem 'spring'
+  
+  # open sent emails in the browser
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (6.0.3)
     bcrypt (3.1.10)
     builder (3.2.2)
@@ -125,6 +126,10 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.0)
+      launchy (~> 2.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -271,6 +276,7 @@ DEPENDENCIES
   http_accept_language
   jbuilder (~> 2.2)
   jquery-rails
+  letter_opener
   mysql2
   non-stupid-digest-assets
   omniauth-google-oauth2

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -70,7 +70,30 @@ class RepliesController < ApplicationController
           @reply.save!
 
           @reply.notified_users.each do |user|
-            mail = NotificationMailer.new_reply(@reply, user)
+            mail = if Tenant.current_tenant.include_conversation_in_replies?
+              @ticket = @reply.ticket
+              @replies = @reply.ticket.replies.reverse.select do |reply| 
+                # Here, we have to decide which replies to include in the conversation
+                # that is sent to the client.
+                # 
+                #   1. Do not include internal notes without recipient.
+                #   2. Do not include internal questions to other agents.
+                #   3. Do not include internal response from other agents.
+                #   4. Include all replies that have the user as recipient.
+                #   5. Include all external replies from the user.
+                #   6. Incldue all external replies from other users, since
+                #       a. clients tend to reply from different email addresses, and
+                #       b. we often need confirmations from other external staff like
+                #            "I confirm that you may grant this person admin permissions."
+                #
+                reply.notified_users.include?(user) or  # 1., 2., 3., 4.
+                reply.user == user or                   # 1., 2., 3.,     5.
+                !reply.user.agent?                      # 1., 2., 3.,         6.
+              end
+              NotificationMailer.new_reply_with_conversation(@replies, @ticket, user)
+            else
+              NotificationMailer.new_reply(@reply, user)
+            end
 
             mail.deliver_now unless EmailAddress.pluck(:email).include?(user.email)
             @reply.message_id = mail.message_id

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -38,7 +38,10 @@ class SettingsController < ApplicationController
     params.require(:tenant).permit(
       :default_time_zone,
       :ignore_user_agent_locale,
-      :default_locale
+      :default_locale,
+      :include_conversation_in_replies,
+      :reply_email_footer,
+      :logo_url
     )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,16 @@ class User < ActiveRecord::Base
       where('LOWER(email) LIKE ? ESCAPE ?', term, '!')
     end
   }
+  
+  def greeting
+    if Time.zone.now > "4:00".to_time and Time.zone.now < "11:00".to_time
+      I18n.t(:good_morning, locale: locale)
+    elsif Time.zone.now > "11:00".to_time and Time.zone.now < "17:00".to_time
+      I18n.t(:good_day, locale: locale)
+    else
+      I18n.t(:good_evening, locale: locale)
+    end
+  end
 
   def self.agents_to_notify
     User.agents

--- a/app/views/notification_mailer/new_reply_with_conversation.html.erb
+++ b/app/views/notification_mailer/new_reply_with_conversation.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div style="overflow: hidden">
             <small>
-              <%= @ticket.reply_from_address %>,
+              <%= reply.user.agent? ? @ticket.reply_from_address : reply.user.email %>,
               <%= localize(reply.created_at) %>
             </small>
             <div class="reply_body">

--- a/app/views/notification_mailer/new_reply_with_conversation.html.erb
+++ b/app/views/notification_mailer/new_reply_with_conversation.html.erb
@@ -1,0 +1,61 @@
+<style>
+  .reply_body { background-color: white; border: 1px solid #DBDBDB; -webkit-border-radius: 3px; border-radius: 3px; display: block; margin: 6px 0; padding: 10px 12px 0 12px; margin-right: 40px }
+  img.avatar { -webkit-border-radius: 3px; border-radius: 3px; }
+</style>
+<div style="font-family: Helvetica; background-color: #F0F0F0">
+  <div class="header" style="background-color: #337ab7; color: #ffffff; margin-top: 0; margin-left: 0; margin-right: 0; margin-bottom: 20px; padding: 20px;">
+    <%= image_tag Tenant.current_tenant.logo_url, align: 'right' if Tenant.current_tenant.logo_url.present? %>
+    <p><%= @title %></p>
+  </div>
+  <ul>
+    <% @replies.each do |reply| %>
+      <li style="list-style: none; margin-bottom: 20px; margin-top: 20px">
+        <div class="reply">
+          <div style="float: left; margin-right: 10px">
+            <%= user_avatar(reply.user, size: 32) %>
+          </div>
+          <div style="overflow: hidden">
+            <small>
+              <%= @ticket.reply_from_address %>,
+              <%= localize(reply.created_at) %>
+            </small>
+            <div class="reply_body">
+              <p>
+                <% if reply.content_type == 'html' %>
+                  <%= sanitize_html(reply.content_without_quotes) %>
+                <% else %>
+                  <pre><%= reply.content_without_quotes %></pre>
+                <% end %>
+              </p>
+            </div>
+          </div>
+        </div>
+      </li>
+    <% end %>
+    <li style="list-style: none; margin-bottom: 20px; margin-top: 20px">
+      <div class="reply">
+        <div style="float: left; margin-right: 10px">
+          <%= user_avatar(@ticket.user, size: 32) %>
+        </div>
+        <div style="overflow: hidden">
+          <small>
+            <%= @ticket.user.email %>,
+            <%= localize(@ticket.created_at) %>
+          </small>
+          <div class="reply_body">
+            <p>
+              <% if @ticket.content_type == 'html' %>
+                <%= sanitize_html(@ticket.content) %>
+              <% else %>
+                <pre><%= @ticket.content %></pre>
+              <% end %>
+            </p>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <div class="footer" style="background-color: white; padding-top: 10px">
+    <small><%= Tenant.current_tenant.reply_email_footer.html_safe %></small>
+  </div>
+</div>

--- a/app/views/notification_mailer/new_reply_with_conversation.html.erb
+++ b/app/views/notification_mailer/new_reply_with_conversation.html.erb
@@ -5,6 +5,7 @@
 <div style="font-family: Helvetica; background-color: #F0F0F0">
   <div class="header" style="background-color: #337ab7; color: #ffffff; margin-top: 0; margin-left: 0; margin-right: 0; margin-bottom: 20px; padding: 20px;">
     <%= image_tag Tenant.current_tenant.logo_url, align: 'right' if Tenant.current_tenant.logo_url.present? %>
+    <p><%= @user.greeting %>!</p>
     <p><%= @title %></p>
   </div>
   <ul>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -20,6 +20,14 @@
     </div>
 
     <div class="medium-6 columns">
+
+      <h5><%= t(:reply_email_settings) %></h5>
+
+      <%= f.check_box :include_conversation_in_replies %>
+      
+      <%= f.text_area :reply_email_footer %>
+      
+      <%= f.text_field :logo_url %>
     </div>
   </div>
   <div class="row">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -99,7 +99,7 @@ de:
   attach_file: Datei anhängen
   send_reply: Anwort senden
   on_date_author_wrote: 'Am %{date} hat %{author} folgendes geschrieben:'
-  on_date_author_wrote_regex: 'Am [0-9].*geschrieben:.*'
+  on_date_author_wrote_regex: 'Am [0-9].*geschrieben:.*|Am [0-9].*schrieb.*:.*|Von:.*\@.*'
   notification_will_be_sent_to: 'Es wird eine Benachrichtung an folgende Adresse gesendet:'
 
 # ticket_mailer/notify_assigned.text.erb

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -116,6 +116,9 @@ de:
 # notification_mailer/new_reply
   new_reply: Antwort
   view_new_reply: Antwort anzeigen
+  good_morning: Guten Morgen
+  good_day: Guten Tag
+  good_evening: Guten Abend
 
 # attachments/_attachment
   download: Öffnen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -144,6 +144,14 @@ de:
   access_control: Zugriff gestatten
   have_access_to_label: 'Der Benutzer darf nur Tickets mit diesen Labels öffnen:'
 
+# settings/edit
+  change_settings: Einstellungen anpassen
+  localization_settings: Sprache und Zeitzone
+  reply_email_settings: Antwort-E-Mail-Einstellungen
+  
+# controllers/settings
+  settings_saved: Einstellungen gespeichert
+
 # controllers/attachments
   file_not_found: Datei nicht gefunden
 
@@ -237,3 +245,11 @@ de:
         email: E-Mail-Adresse
         default: Als Standard-E-Mail-Adresse für ausgehende Nachrichten verwenden
         verification_token: Verifiziert
+
+      tenant:
+        default_locale: Standard-Sprache
+        ignore_user_agent_locale: Sprache des Browsers ignorieren
+        default_time_zone: Standard-Zeitzone
+        include_conversation_in_replies: Konversation in Antwort-E-Mails einbeziehen
+        logo_url: Logo-URL
+        reply_email_footer: Antwort-E-Mail-Fußzeile

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -99,6 +99,7 @@ de:
   attach_file: Datei anhängen
   send_reply: Anwort senden
   on_date_author_wrote: 'Am %{date} hat %{author} folgendes geschrieben:'
+  on_date_author_wrote_regex: 'Am [0-9].*geschrieben:.*'
   notification_will_be_sent_to: 'Es wird eine Benachrichtung an folgende Adresse gesendet:'
 
 # ticket_mailer/notify_assigned.text.erb

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,7 @@ en:
   attach_file: Attach file
   send_reply: Send reply
   on_date_author_wrote: 'On %{date}, %{author} wrote:'
-  on_date_author_wrote_regex: 'On .*wrote:.*'
+  on_date_author_wrote_regex: 'On .*wrote:.*|From:.*\@.*'
   notification_will_be_sent_to: Your notification will be sent to
   save_as_draft: Save as draft
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,7 @@ en:
 # settings/edit
   change_settings: Change settings
   localization_settings: Localization settings
+  reply_email_settings: Reply email settings
 
 # controllers/settings
   settings_saved: Settings saved
@@ -279,3 +280,6 @@ en:
         default_locale: Default language
         ignore_user_agent_locale: Ignore preferred browser language
         default_time_zone: Default time zone
+        include_conversation_in_replies: Include conversation in reply emails
+        logo_url: Logo url
+        reply_email_footer: Reply email footer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,9 @@ en:
 # notification_mailer/new_reply
   new_reply: New reply
   view_new_reply: View new reply
+  good_morning: Good morning
+  good_day: Good day
+  good_evening: Good evening
 
 # attachments/_attachment
   download: download

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
   attach_file: Attach file
   send_reply: Send reply
   on_date_author_wrote: 'On %{date}, %{author} wrote:'
+  on_date_author_wrote_regex: 'On .*wrote:.*'
   notification_will_be_sent_to: Your notification will be sent to
   save_as_draft: Save as draft
 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -161,6 +161,7 @@ nl:
 # settings/edit
   change_settings: Wijzig instellingen
   localization_settings: Localizatie instellingen
+  reply_email_settings: Reactie E-mailinstellingen
 
 # controllers/settings
   settings_saved: Instellingen opgeslagen

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -130,6 +130,9 @@ nl:
 # notification_mailer/new_reply
   new_reply: Nieuwe reactie
   view_new_reply: Nieuwe reactie bekijken
+  good_morning: Goedemorgen
+  good_day: Goedendag
+  good_evening: Goedenavond
 
 # attachments/_attachment
   download: download

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -108,6 +108,7 @@ nl:
   attach_file: Bestand toevoegen
   send_reply: Verstuur reactie
   on_date_author_wrote: 'Op %{date} schreef %{author}:'
+  on_date_author_wrote_regex: 'Op .*schreef.*:.*'
   notification_will_be_sent_to: Een notificatie van je reactie wordt verstuurd naar
   save_as_draft: Als concept opslaan
 

--- a/db/migrate/20150909055225_add_include_conversation_in_replies_to_tenants.rb
+++ b/db/migrate/20150909055225_add_include_conversation_in_replies_to_tenants.rb
@@ -1,0 +1,18 @@
+class AddIncludeConversationInRepliesToTenants < ActiveRecord::Migration
+  def change
+    if Tenant.postgresql?
+      old = Tenant.connection.schema_search_path
+      Tenant.connection.schema_search_path = 'public'
+    end
+
+    unless column_exists? :tenants, :include_conversation_in_replies
+      add_column :tenants, :include_conversation_in_replies, :boolean, default: false, null: false
+      add_column :tenants, :logo_url, :string
+      add_column :tenants, :reply_email_footer, :text
+    end
+
+    if Tenant.postgresql?
+      Tenant.connection.schema_search_path = old
+    end
+  end
+end


### PR DESCRIPTION
## Overview

#### When the feature is activated in the global tenant settings …

![bildschirmfoto 2015-09-09 um 23 09 23](https://cloud.githubusercontent.com/assets/1679688/9774328/037b1860-5748-11e5-8a43-9276d0a3fe04.png)

#### … the past conversation is included in reply emails sent to the customers:

![bildschirmfoto 2015-09-09 um 23 11 43](https://cloud.githubusercontent.com/assets/1679688/9774381/6950318e-5748-11e5-88dc-d7cb2d99fc9b.png)

## Why

We had several clients that did not recall several details from previous emails, including their own emails as well as emails by the support team. This conversation feature helps them to browse through the conversation quickly – hopefully reducing the workload of the support team.

## Who has it

* I think, *Zendesk* uses this feature.
* *Uservoice* [decided against that feature](http://feedback.uservoice.com/forums/1-general-feedback/suggestions/3059343-display-message-history-on-the-emails-the-customer).

## Whose replies are included in the conversation

1. Do **not include internal notes** without recipient.
2. Do not include internal questions to other agents.
3. Do not include internal response from other agents.
4. Include all replies that have the user as recipient.
5. Include all external replies from the user.
6. **Incldue all external replies** from other users, since
   (a.) clients tend to reply from different email addresses, and
   (b.) we often need confirmations from other external staff like
         "I confirm that you may grant this person admin permissions."