### PR TITLE
New feature: Merge tickets

### DIFF
--- a/app/controllers/tickets/selected_controller.rb
+++ b/app/controllers/tickets/selected_controller.rb
@@ -21,6 +21,7 @@ module Tickets
 
     def update
       @tickets = Ticket.where(id: params[:id])
+      return perform_merge if merge?
 
       authorize! :update, Ticket # for empty params[:id]
 
@@ -36,6 +37,18 @@ module Tickets
 
     def ticket_params
       params.require(:ticket).permit(:status)
+    end
+    
+    def merge?
+      params[:merge] == "true"
+    end
+    
+    def perform_merge
+      authorize! :update, Ticket
+      @tickets.each { |ticket| authorize! :update, ticket }
+      
+      merged_ticket = Ticket.merge @tickets, current_user: current_user
+      redirect_to merged_ticket, notice: t(:tickets_have_been_merged)
     end
   end
 end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -76,6 +76,10 @@ class TicketsController < ApplicationController
       .filter_by_assignee_id(params[:assignee_id])
       .filter_by_user_id(params[:user_id])
       .ordered
+    
+    if params[:status] != 'merged'
+      @tickets = @tickets.where.not(status: Ticket.statuses[:merged])
+    end
 
     respond_to do |format|
       format.html do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,16 +38,4 @@ module ApplicationHelper
     end
     super(*[collection_or_options, options].compact)
   end
-
-  def status_icon(status)
-    if status == 'closed'
-      'check'
-    elsif status == 'deleted'
-      'trash-o'
-    elsif status == 'waiting'
-      'clock-o'
-    else
-      'inbox'
-    end
-  end
 end

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -1,0 +1,24 @@
+module IconHelper
+  
+  def status_icon(status, options = {assigned_to_me: false})
+    content_tag(:span, '', class: status_icon_class(status, options)).html_safe
+  end
+  
+  def status_icon_class(status, options = {assigned_to_me: false})
+    case status
+    when 'open'
+      if options[:assigned_to_me]
+        "fa fa-user"
+      else
+        "fa fa-inbox"
+      end
+    when 'waiting'
+      "fa fa-clock-o"
+    when 'closed'
+      "fa fa-check"
+    when 'deleted'
+      "fa fa-trash-o"
+    end
+  end
+  
+end

--- a/app/models/concerns/ticket_merge.rb
+++ b/app/models/concerns/ticket_merge.rb
@@ -33,7 +33,8 @@ concern :TicketMerge do
       raw_message_file_name: self.raw_message_file_name,
       raw_message_content_type: self.raw_message_content_type,
       raw_message_file_size: self.raw_message_file_size,
-      raw_message_updated_at: self.raw_message_updated_at
+      raw_message_updated_at: self.raw_message_updated_at,
+      attachments: self.attachments.collect { |attachment| attachment.dup }
     )
   end
   

--- a/app/models/concerns/ticket_merge.rb
+++ b/app/models/concerns/ticket_merge.rb
@@ -1,0 +1,54 @@
+concern :TicketMerge do
+  class_methods do
+
+    # Merge two tickets like this:
+    #
+    #     separate_tickets = [first_ticket, second_ticket]
+    #     merged_ticket = Ticket.merge separate_tickets
+    #
+    # Options:
+    #
+    #     current_user: The agent that is performing the merge.
+    #       Use the current_user when merging from a controller.
+    #
+    def merge(separate_tickets, options = {})
+      MergedTicket.from separate_tickets, options
+    end
+    
+  end
+  
+  # When converting separate tickets to a merged ticket, this
+  # method allows to convert the message of a ticket to a reply:
+  #
+  #     reply = ticket.to_reply
+  #
+  def to_reply
+    Reply.new(
+      content: self.content,
+      created_at: self.created_at,
+      updated_at: self.updated_at,
+      user_id: self.user_id,
+      message_id: self.message_id,
+      content_type: self.content_type,
+      raw_message_file_name: self.raw_message_file_name,
+      raw_message_content_type: self.raw_message_content_type,
+      raw_message_file_size: self.raw_message_file_size,
+      raw_message_updated_at: self.raw_message_updated_at
+    )
+  end
+  
+  # Create an internal note that describes the ticket merge.
+  #
+  def create_merge_notice(refer_to_ticket, merging_user)
+    message = I18n.with_locale(merging_user.locale) {
+      I18n.translate :ticket_has_been_merged_to, ticket_id: refer_to_ticket.id
+    }
+    
+    self.replies.create(
+      content: message,
+      user_id: merging_user.id,
+      internal: true
+    )
+  end
+  
+end

--- a/app/models/merged_ticket.rb
+++ b/app/models/merged_ticket.rb
@@ -26,7 +26,7 @@ class MergedTicket < Ticket
     oldest_original_ticket.replies << copies_of_the_replies_of_the_younger_tickets
     oldest_original_ticket.replies << younger_tickets.collect { |ticket| ticket.to_reply }
     younger_tickets.each { |ticket| ticket.create_merge_notice(oldest_original_ticket, current_user) } if current_user
-    younger_tickets.each { |ticket| ticket.status = :closed; ticket.save }
+    younger_tickets.each { |ticket| ticket.status = :merged; ticket.save }
     return oldest_original_ticket
   end
   

--- a/app/models/merged_ticket.rb
+++ b/app/models/merged_ticket.rb
@@ -1,0 +1,63 @@
+# This represents a ticket that has just been merged from separate tickets.
+#
+# Merge two tickets like this:
+#
+#     separate_tickets = [first_ticket, second_ticket]
+#     merged_ticket = MergedTicket.from separate_tickets
+#
+# When providing a current_user, a merge notice is created in the other tickets
+# referring to the merged ticket.
+#
+#     merged_ticket = MergedTicket.from separate_tickets, current_user: current_user
+#
+class MergedTicket < Ticket
+  
+  def initialize(separate_tickets, options = {})
+    @original_tickets = separate_tickets
+    @current_user = options[:current_user]
+    return self
+  end
+  
+  def self.from(separate_tickets, options = {})
+    self.new(separate_tickets, options).merge
+  end
+  
+  def merge
+    oldest_original_ticket.replies << copies_of_the_replies_of_the_younger_tickets
+    oldest_original_ticket.replies << younger_tickets.collect { |ticket| ticket.to_reply }
+    younger_tickets.each { |ticket| ticket.create_merge_notice(oldest_original_ticket, current_user) } if current_user
+    younger_tickets.each { |ticket| ticket.status = :closed; ticket.save }
+    return oldest_original_ticket
+  end
+  
+  def current_user
+    @current_user
+  end
+  
+  def original_tickets
+    @original_tickets || raise('not properly initialized. @original_tickets are missing.')
+  end
+  
+  def oldest_original_ticket
+    @oldest_original_ticket ||= original_tickets.sort_by { |ticket| ticket.created_at }.first
+  end
+  
+  def younger_tickets
+    original_tickets.select { |ticket| ticket.id != oldest_original_ticket.id }
+  end
+  
+  def replies_of_the_younger_tickets
+    younger_tickets.collect { |ticket| ticket.replies }.flatten
+  end
+  
+  def copies_of_the_replies_of_the_younger_tickets
+    replies_of_the_younger_tickets.collect do |reply| 
+      reply_copy = reply.dup 
+      reply_copy.created_at = reply.created_at
+      reply_copy.updated_at = reply.updated_at
+      reply
+    end
+  end
+  
+end
+

--- a/app/models/merged_ticket.rb
+++ b/app/models/merged_ticket.rb
@@ -55,6 +55,7 @@ class MergedTicket < Ticket
       reply_copy = reply.dup 
       reply_copy.created_at = reply.created_at
       reply_copy.updated_at = reply.updated_at
+      reply_copy.attachments << reply.attachments.collect { |attachment| attachment.dup }
       reply
     end
   end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -17,6 +17,7 @@
 class Ticket < ActiveRecord::Base
   include CreateFromUser
   include EmailMessage
+  include TicketMerge
 
   validates_presence_of :user_id
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -35,7 +35,7 @@ class Ticket < ActiveRecord::Base
 
   has_many :status_changes, dependent: :destroy
 
-  enum status: [:open, :closed, :deleted, :waiting]
+  enum status: [:open, :closed, :deleted, :waiting, :merged]
   enum priority: [:unknown, :low, :medium, :high]
 
   after_update :log_status_change

--- a/app/views/application/_inbox_menu.html.erb
+++ b/app/views/application/_inbox_menu.html.erb
@@ -3,7 +3,7 @@
       params[:assignee_id].to_i == 0,
       href: root_path do %>
 
-    <span class="fa fa-inbox"></span>
+    <%= status_icon 'open' %>
     <%= t(:inbox) %>
     <span class="right heading-six bubble pls prs">
       <%= Ticket.viewable_by(current_user).open.count %>
@@ -15,7 +15,7 @@
     <%= active_elem_if :a, params[:status] == 'open' &&
         params[:assignee_id].to_i == current_user.id,
         href: tickets_path(assignee_id: current_user.id), class: 'plxxl' do %>
-      <span class="fa fa-user"></span>
+      <%= status_icon 'open', assigned_to_me: true %>
       <%= t(:mine) %>
       <span class="right heading-six bubble pls prs">
         <%= Ticket.viewable_by(current_user).open.filter_by_assignee_id( current_user.id).count %>
@@ -26,7 +26,7 @@
 <li>
   <%= active_elem_if :a, params[:status] == 'waiting',
       href: tickets_path(status: 'waiting') do %>
-    <span class="fa fa-clock-o"></span>
+    <%= status_icon 'waiting' %>
     <%= t('activerecord.attributes.ticket.statuses.waiting') %>
     <span class="right heading-six bubble pls prs">
       <%= Ticket.viewable_by(current_user).waiting.count %>
@@ -36,13 +36,13 @@
 <li>
   <%= active_elem_if :a, params[:status] == 'closed',
        href: tickets_path(status: 'closed') do %>
-    <span class="fa fa-check"></span><%= t(:closed_tickets) %>
+    <%= status_icon 'closed' %><%= t(:closed_tickets) %>
   <% end %>
 </li>
 <li>
   <%= active_elem_if :a, params[:status] == 'deleted',
       href: tickets_path(status: 'deleted') do %>
-    <span class="fa fa-trash-o"></span><%= t(:trashed) %>
+    <%= status_icon 'deleted' %><%= t(:trashed) %>
   <% end %>
 </li>
 

--- a/app/views/tickets/_status_dropdown.html.erb
+++ b/app/views/tickets/_status_dropdown.html.erb
@@ -1,10 +1,10 @@
 <ul id="statuses-<%= ticket.id %>" class="f-dropdown" data-dropdown-content>
-  <% Ticket.statuses.keys.each do |value| %>
+  <% Ticket.statuses.except(:merged).keys.each do |value| %>
     <li>
       <%= link_to ticket_path(ticket, ticket: { status: value }),
           method: :patch, remote: true do %>
 
-        <span class="fa fa-fw fa-<%= status_icon(value) %>"></span>
+        <span class="fa-fw <%= status_icon_class(value) %>"></span>
         <%= t(value, scope: 'activerecord.attributes.ticket.statuses') %>
       <% end %>
     </li>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -60,6 +60,11 @@
           </button>
         </li>
       <% end %>
+      <li class="bl no-m">
+        <button type="submit" name="merge" value="true" class="ptl plm prm pbl text-medium-light-grey no-m no-b" title="<%=t :merge_explanation %>">
+          <%= t :merge %>
+        </button>
+      </li>
     </ul>
     <% @tickets.each do |ticket| %>
       <div class="priority-<%= ticket.priority %> row ticket bb" style="height: 4em;" data-ticket-url="<%= ticket_url(ticket) %>">

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -53,7 +53,7 @@
       <li class="pal no-m prm">
         <input type="checkbox" value="" name="" class="no-mb mts left" data-toggle-all />
       </li>
-      <% Ticket.statuses.except(params[:status]).keys.each do |value| %>
+      <% Ticket.statuses.except(params[:status]).except(:merged).keys.each do |value| %>
         <li class="bl no-m">
           <button type="submit" name="ticket[status]" value="<%= value %>" class="ptl plm prm pbl text-medium-light-grey no-m no-b">
             <%= t(value, scope: 'activerecord.attributes.ticket.statuses') %>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -99,6 +99,12 @@
           <% else %>
             <span>&nbsp;</span>
           <% end %>
+          <% if params[:status].nil? %>
+            <span class="ba label radius right alt text-secondary">
+              <%= status_icon(ticket.status, assigned_to_me: ticket.assignee == current_user) %>
+              <%= t ticket.status %>
+            </span>
+          <% end %>
         </div>
         <div class="medium-2 v-middle columns">
           <% ticket.labels.viewable_by(current_user).each do |label| %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -33,13 +33,13 @@
           <li class="ib mrl">
             <% if can? :update, @ticket %>
               <a href="#" data-dropdown="statuses-<%= @ticket.id %>">
-                <span class="fa fa-fw fa-<%= status_icon(@ticket.status) %> text-default"></span>
+                <span class="fa-fw <%= status_icon_class(@ticket.status) %> text-default"></span>
                 <span class="show-for-print hide"><%= t(:status) %>:</span>
                 <%= t(@ticket.status, scope: 'activerecord.attributes.ticket.statuses') %>
               </a>
               <%= render 'status_dropdown', ticket: @ticket %>
             <% else %>
-              <span class="fa fa-fw fa-<%= status_icon(@ticket.status) %>"></span>
+              <span class="fa-fw <%= status_icon_class(@ticket.status) %>"></span>
               <span class="show-for-print hide"><%= t(:status) %>:</span>
               <%= t(@ticket.status, scope: 'activerecord.attributes.ticket.statuses') %>
             <% end %>

--- a/app/views/tickets/update.js.erb
+++ b/app/views/tickets/update.js.erb
@@ -1,7 +1,7 @@
 <% if !params[:ticket][:status].blank? %>
   jQuery('[data-dropdown="statuses-<%= @ticket.id %>"]')
       .empty()
-      .append('<span class="fa fa-<%= status_icon(@ticket.status) %>"></span> ' +
+      .append('<span class="<%= status_icon_class(@ticket.status) %>"></span> ' +
           '<%= j(t(@ticket.status, scope: 'activerecord.attributes.ticket.statuses')) %>');
 
 <% elsif !params[:ticket][:priority].blank? %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -95,6 +95,13 @@ de:
   change_assignee: Ticket zuweisen
   assign: Ticket zuweisen
 
+# tickets/merge
+  ticket_has_been_merged_to: "Dieses Ticket wurde mit Ticket #%{ticket_id} zusammengeführt."
+  merge: Zusammenführen
+  merge_explanation: "Ausgewählte Tickets zusammenführen. Dies kopiert die Antworten der ausgewählten Tickets in das älteste diser Tickets. Die übrigen ausgewählten Tickets werden geschlossen."
+  tickets_have_been_merged: "Tickets wurden zusammengeführt."
+  
+
 # replies/new
   add_reply: Antworten
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,12 @@ en:
 
 # tickets/locks/create
   ticket_locked_by_somebody_else: Ticket is currently already being handled by somebody else
+  
+# tickets/merge
+  ticket_has_been_merged_to: "This ticket has been merged to ticket #%{ticket_id}."
+  merge: Merge
+  merge_explanation: "Merge the selected tickets. This copies all replies to the oldest of the selected tickets and closes the other selected tickets."
+  tickets_have_been_merged: "Tickets have been merged."
 
 # replies/new
   add_reply: Add reply

--- a/test/models/merged_ticket_test.rb
+++ b/test/models/merged_ticket_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class TicketMergeTest < ActiveSupport::TestCase
+  
+  test 'merging two tickets' do
+    client_user = User.where(agent: false).first
+    agent_user = User.where(agent: true).first
+    first_ticket = Ticket.create subject: "First ticket", content: "I've got a question ...", user_id: client_user.id
+    Timecop.travel 2.minutes.from_now
+    first_reply = first_ticket.replies.create content: "Please send me some more info about ...", user_id: agent_user.id
+    Timecop.travel 20.minutes.from_now
+    second_ticket = Ticket.create subject: "Second ticket", content: "I forgot to mention ...", user_id: client_user.id
+    Timecop.travel 1.hour.from_now
+    
+    second_ticket_updated_at_before_merge = second_ticket.updated_at
+    
+    separate_tickets = [first_ticket, second_ticket]
+    merged_ticket = MergedTicket.from separate_tickets
+    
+    assert_equal 2, merged_ticket.replies.count
+    assert_equal merged_ticket.id, first_ticket.id
+    assert merged_ticket.replies.pluck(:content).include? "Please send me some more info about ..."
+    assert merged_ticket.replies.pluck(:content).include? "I forgot to mention ..."
+    assert merged_ticket.replies.order(:created_at).first.user == agent_user
+    assert merged_ticket.replies.order(:created_at).last.user == client_user
+    assert_equal merged_ticket.replies.order(:created_at).last.created_at.to_i, second_ticket.created_at.to_i
+    assert_equal merged_ticket.replies.order(:created_at).last.updated_at.to_i, second_ticket_updated_at_before_merge.to_i
+  end
+  
+  test 'merging two tickets and providing an agent who is performing the merge' do
+    client_user = User.where(agent: false).first
+    agent_user = User.where(agent: true).first
+    first_ticket = Ticket.create subject: "First ticket", content: "I've got a question ...", user_id: client_user.id
+    Timecop.travel 2.minutes.from_now
+    second_ticket = Ticket.create subject: "Second ticket", content: "I forgot to mention ...", user_id: client_user.id
+    
+    merged_ticket = MergedTicket.from [first_ticket, second_ticket], current_user: agent_user
+    second_ticket.reload
+    
+    assert_equal 1, merged_ticket.replies.count
+    assert second_ticket.replies.last.user == agent_user
+    assert second_ticket.replies.last.internal == true
+    assert second_ticket.replies.last.content.include? first_ticket.id.to_s
+    assert second_ticket.status == 'closed'
+  end
+  
+  test 'merging two tickets and copying over the notifications' do
+    client_user = User.where(agent: false).first
+    agent_user = User.where(agent: true).first
+    first_ticket = Ticket.create subject: "First ticket", content: "I've got a question ...", user_id: client_user.id
+    Timecop.travel 2.minutes.from_now
+    second_ticket = Ticket.create subject: "Second ticket", content: "I forgot to mention ...", user_id: client_user.id
+    Timecop.travel 4.minutes.from_now
+    second_reply = second_ticket.replies.create content: "Please send me some more info about ...", user_id: agent_user.id
+    second_reply.notified_users << client_user
+    
+    merged_ticket = MergedTicket.from [first_ticket, second_ticket], current_user: agent_user
+
+    assert merged_ticket.replies.order(:created_at).last.notified_users.include? client_user
+  end
+  
+end

--- a/test/models/merged_ticket_test.rb
+++ b/test/models/merged_ticket_test.rb
@@ -41,7 +41,7 @@ class TicketMergeTest < ActiveSupport::TestCase
     assert second_ticket.replies.last.user == agent_user
     assert second_ticket.replies.last.internal == true
     assert second_ticket.replies.last.content.include? first_ticket.id.to_s
-    assert second_ticket.status == 'closed'
+    assert second_ticket.status == 'merged'
   end
   
   test 'merging two tickets and copying over the notifications' do


### PR DESCRIPTION
This pull request introduces a feature to merge several tickets into one. This is useful if a client provides additional information in a separate email.

## Usage

Suppose there are two tickets that actually belong together.

<img width="1021" alt="bildschirmfoto 2015-11-27 um 15 53 30" src="https://cloud.githubusercontent.com/assets/1679688/11443964/f3833a2e-9521-11e5-9a3f-32c4b6c3e693.png">

Select those tickets and click "Merge".

<img width="1019" alt="bildschirmfoto 2015-11-27 um 15 53 45" src="https://cloud.githubusercontent.com/assets/1679688/11443966/00676832-9522-11e5-9159-3a491069cba8.png">

## Result

All replies of the second ticket and the message of the second ticket itself are copied into new replies that belong to the first ticket.

<img width="1017" alt="bildschirmfoto 2015-11-27 um 15 54 24" src="https://cloud.githubusercontent.com/assets/1679688/11443988/2de45a18-9522-11e5-9f48-55114fac431f.png">

Only the first ticket remains with status `:open`.

<img width="1020" alt="bildschirmfoto 2015-11-27 um 15 55 09" src="https://cloud.githubusercontent.com/assets/1679688/11444028/6539cb74-9522-11e5-9c11-b63c6c45627a.png">

The second ticket's status is changed to `:closed`.

<img width="1019" alt="bildschirmfoto 2015-11-27 um 15 55 38" src="https://cloud.githubusercontent.com/assets/1679688/11444048/893c9ed4-9522-11e5-88d5-d06c039117f0.png">

## Next steps

Please let me know what you think of this idea.

I will try this out in production for a couple of days and then post how it went.

### Issues and work to be done

* [x] Keep attachments in `Ticket#to_reply`: https://github.com/ivaldi/brimir/commit/9ea968ed73b7d7e36cacc14c38107d45d0890d95
* [x] Status `:merged`: https://github.com/ivaldi/brimir/commit/cb2a875c1142974fa07368dce30d5766477352be
* [x] Hide `:merged` tickets from `tickets#index`: https://github.com/ivaldi/brimir/commit/5b950f4d9445398ea027f336b59e18c79ce8a539