### PR TITLE
Prevent outgoing e-mail to support address

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -117,7 +117,7 @@ class NotificationMailer < ActionMailer::Base
 
     @reply = reply
     @user = user
-
+    return if EmailAddress.all.to_a.collect(&:email).include?(user.email.to_s)
     mail(to: user.email, subject: title, from: reply.ticket.reply_from_address)
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -117,7 +117,7 @@ class NotificationMailer < ActionMailer::Base
 
     @reply = reply
     @user = user
-    return if EmailAddress.all.to_a.collect(&:email).include?(user.email.to_s)
+    return if EmailAddress.pluck(:email).include?(user.email.to_s)
     mail(to: user.email, subject: title, from: reply.ticket.reply_from_address)
   end
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -43,4 +43,13 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal email_addresses(:brimir).formatted, mail['From'].to_s
   end
 
+  # Preventing infinite email loops
+  test 'should not notify our own outgoing addresses' do
+    reply = replies(:solution)
+    our_email = email_addresses(:support)
+    assert_no_difference 'ActionMailer::Base.deliveries.size' do
+      NotificationMailer.new_reply(reply, User.new(email: our_email.email)).deliver_now
+    end
+  end
+
 end


### PR DESCRIPTION
This is intended to prevent a situation where an
infinite loop of e-mails can be created by accidentaly
notifying our own e-mail when responding to a ticket.