### PR TITLE
Add New Ticket button on mobile screens

### DIFF
--- a/app/assets/stylesheets/_topbar.scss
+++ b/app/assets/stylesheets/_topbar.scss
@@ -13,6 +13,23 @@
 				}
 			}
 		}
+
+		.left {
+			left: 1rem;
+		}
+
+		.collapsed-only {
+			@media #{$small-only} {
+				display: inline-block;
+				top: 50%;
+				margin-top: -1rem;
+				position: absolute;
+			}
+
+			@media #{$medium-up} {
+				display: none;
+			}
+		}
 	}
 
 	.top-bar-section{

--- a/app/assets/stylesheets/_topbar.scss
+++ b/app/assets/stylesheets/_topbar.scss
@@ -9,6 +9,7 @@
 			h1{
 				a{
 					font-size: 22px;
+					width: 100%;
 				}
 			}
 		}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,11 @@
     <% if user_signed_in? %>
       <nav class="top-bar" data-topbar>
         <ul class="title-area medium-3 large-2">
+          <% if can? :create, Ticket %>
+            <li class="collapsed-only left">
+              <a href="<%= new_ticket_path %>" class="button info"><i class="fa fa-plus fa-fw"></i></a>
+            </li>
+          <% end %>
           <li class="name">
             <h1><a href="<%= root_path %>">BRIMIR</a></h1>
           </li>


### PR DESCRIPTION
This improves mobile support by adding a New Ticket button on the top bar for small viewports. It also fixes the header text being off center.

![Example](http://i.imgur.com/OUppcJJ.png)