### PR TITLE
Do not notify other clients silently, when a client replies via email.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'byebug', group: [:development, :test]
 group :development do
   # Spring application pre-loader
   gem 'spring'
+  
+  # open sent emails in the browser
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'foundation_rails_helper'
 
 # to use debugger
 gem 'byebug', group: [:development, :test]
+gem 'pry', group: [:development, :test]
 
 group :development do
   # Spring application pre-loader

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       activesupport (>= 3.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
+    coderay (1.1.0)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -130,6 +131,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.99.1)
     mimemagic (0.3.0)
     mini_portile2 (2.0.0)
@@ -166,6 +168,10 @@ GEM
       mime-types
       mimemagic (= 0.3.0)
     pg (0.18.4)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -216,6 +222,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     spring (1.6.4)
     sprockets (2.12.4)
       hike (~> 1.2)
@@ -270,6 +277,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   paperclip
   pg
+  pry
   rails (~> 4.2.0)
   rails-i18n
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (6.0.3)
     bcrypt (3.1.10)
     builder (3.2.2)
@@ -121,6 +122,10 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -260,6 +265,7 @@ DEPENDENCIES
   http_accept_language
   jbuilder (~> 2.2)
   jquery-rails
+  letter_opener
   mysql2
   omniauth-google-oauth2
   paperclip

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -77,15 +77,7 @@ class RepliesController < ApplicationController
       else
         Reply.transaction do
           @reply.save!
-
-          @reply.notified_users.each do |user|
-            mail = NotificationMailer.new_reply(@reply, user)
-
-            mail.deliver_now unless EmailAddress.pluck(:email).include?(user.email)
-            @reply.message_id = mail.message_id
-          end
-
-          @reply.save!
+          @reply.notify_users
         end
 
         redirect_to @reply.ticket, notice: I18n::translate(:reply_added)

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -77,7 +77,7 @@ class RepliesController < ApplicationController
       else
         Reply.transaction do
           @reply.save!
-          @reply.notify_users
+          @reply.notification_mails.each(&:deliver_now)
         end
 
         redirect_to @reply.ticket, notice: I18n::translate(:reply_added)

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -21,7 +21,7 @@ class NotificationMailer < ActionMailer::Base
   def self.incoming_message(ticket_or_reply, original_message)
     if ticket_or_reply.is_a? Reply
       reply = ticket_or_reply
-      reply.set_default_notifications!
+      reply.set_default_notifications!(original_message)
       reply.notify_users
     else
       ticket = ticket_or_reply

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -118,7 +118,11 @@ class NotificationMailer < ActionMailer::Base
     @reply = reply
     @user = user
     return if EmailAddress.pluck(:email).include?(user.email.to_s)
-    mail(to: user.email, subject: title, from: reply.ticket.reply_from_address)
+    
+    displayed_to_field = reply.notified_users.where(agent: false).pluck(:email)
+    displayed_to_field = user.email if displayed_to_field.empty?
+    mail(smtp_envelope_to: user.email, to: displayed_to_field,
+      subject: title, from: reply.ticket.reply_from_address)
   end
 
   def status_changed(ticket)

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -22,19 +22,7 @@ class NotificationMailer < ActionMailer::Base
     if ticket_or_reply.is_a? Reply
       reply = ticket_or_reply
       reply.set_default_notifications!
-
-      message_id = nil
-
-      reply.notified_users.each do |user|
-        message = NotificationMailer.new_reply(reply, user)
-        message.message_id = message_id
-        message.deliver_now
-
-        reply.message_id = message.message_id
-        message_id = message.message_id
-      end
-
-      reply.save
+      reply.notify_users
     else
       ticket = ticket_or_reply
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -22,7 +22,7 @@ class NotificationMailer < ActionMailer::Base
     if ticket_or_reply.is_a? Reply
       reply = ticket_or_reply
       reply.set_default_notifications!(original_message)
-      reply.notify_users
+      reply.notification_mails.each(&:deliver_now)
     else
       ticket = ticket_or_reply
 

--- a/app/models/concerns/reply_notifications.rb
+++ b/app/models/concerns/reply_notifications.rb
@@ -92,10 +92,11 @@
 #          are listed in `To`. This way, the clients can include
 #          the other recipients in their replies intentionally.
 #
-# In order to distinguish notifications that are to be delivered
-# through brimir and notifications that are already sent, we use the
-# `Notification#state` attribute. Only notifications that are 
-# `due` are to be sent through brimir.
+# In order to distinguish notifications that are to be delivered through
+# brimir and notifications that are already sent, the other recipients
+# from the `original_message` are added **after** delivering the
+# notifications (`reply.notification_mails.each(&:deliver_now)`) in the 
+# `NotificationMailer`.
 
 
 # ## Why is this important.

--- a/app/models/concerns/reply_notifications.rb
+++ b/app/models/concerns/reply_notifications.rb
@@ -1,3 +1,113 @@
+# This file concerns notifications about replies, particularly, who should
+# be notified about new replies.
+#
+# In order to determine the users to notify about a reply, there are several
+# cases to distinguish.
+
+
+# ## How is the reply sent?
+#
+# (1) The user may reply via the web ui of brimir.
+# 
+#       - The ticket system suggests recipients based on the former
+#         conversation.
+#       - The user can change the recipients in the web form before
+#         sending the reply.
+#
+# (2) The user may reply via email to support@example.com.
+# 
+#       - The ticket system has to determine who, at least, needs to
+#         be notified, since the user just writes to support@example.com,
+#         not to the separate clients or agents.
+#       - The user might add additional recipients by including them
+#         in the `To`, `CC` or `BCC` fields in the email client.
+
+
+# ## Who is sending the reply?
+#
+# (a) The reply author can be an agent.
+# 
+#       - Agents can reply to agents and clients via email to
+#         support@example.com.
+#       - This mechanism mainly is a convenience shortcut if there is
+#         only one possible recipient, i.e. the client that
+#         asked the question.
+#       
+# (b) The reply author can be a client.
+#
+#       - Clients can only reply to agents via email to
+#         support@example.com.
+#       - This is to make sure that it is always transparent
+#         who will get the reply.
+#       - If they need to add other recipients, they can add them
+#         in the `To`, `CC` or `BCC` field.
+
+
+# ## Who is added to `notified_users`?
+#
+# The association `Reply#notified_users` saves who has been notified
+# about a certain reply.
+#
+# (i) Users that have received a notification through brimir.
+#       These can be agents or clients.
+#
+# (ii) Users that are listed in `To` or `CC` when the reply created
+#       via email. These notifications are not sent by brimir,
+#       since these recipients receive emails directly from the
+#       sender.
+
+
+# ## Who will be notified by brimir?
+#
+# (a) If the reply author is an agent:
+#
+#      The agent always sends replies through the ticket system, either
+#      through the web ui (1) or via email to support@example.com (2).
+#      Thus, the ticket system is responsible to deliver the reply to the
+#      recipients.
+#
+#      => Send notifications to agents and clients. (1)(a)(i), (2)(a)(i)
+#
+# (b) If the reply author is a client:
+#
+#      (1) Through the web ui, there is no sending email client involved.
+#
+#          => Send notifications to agents and clients. (1)(b)(i)
+#
+#      (2) Via email to support@example.com, the clients explicitly sends
+#          to other clients using the `To`, `CC`, `BCC` fields of his email
+#          client. Thus, the ticket system is only responsible to deliver
+#          to the agents.
+#
+#          => Send notifications only to agents. (2)(b)(i)
+
+
+# ## Who will be listed in `To`, who in `BCC`?
+#
+#  - (a) In emails to clients, agents are never listed as `To`
+#          in order not to reveal the private email addresses
+#          of the agents.
+#
+#  - (b) In emails to clients, other client-recipients' email addresses
+#          are listed in `To`. This way, the clients can include
+#          the other recipients in their replies intentionally.
+#
+# In order to distinguish notifications that are to be delivered
+# through brimir and notifications that are already sent, we use the
+# `Notification#state` attribute. Only notifications that are 
+# `due` are to be sent through brimir.
+
+
+# ## Why is this important.
+#
+# For an example test case, see:
+#   ReplyTest#test_should_not_notify_other_clients_when_one_of_the_clients_replies
+#   test/models/reply_test.rb
+#
+# The issue is discussed on github:
+# https://github.com/ivaldi/brimir/issues/259
+
+
 concern :ReplyNotifications do
   
   included do

--- a/app/models/concerns/reply_notifications.rb
+++ b/app/models/concerns/reply_notifications.rb
@@ -33,6 +33,13 @@ concern :ReplyNotifications do
     end
   end
   
+  # # This is called from `NotificationMailer#incoming_message` after delivering
+  # # the notifications (i).
+  # #
+  # def add_notifications_based_on_mail_message(mail_message)
+  #   self.notified_users << notified_users_based_on_mail_message(mail_message)  # (ii)
+  # end
+  
   def notify_users
     self.message_id = nil
     notified_users.each do |user|
@@ -43,5 +50,12 @@ concern :ReplyNotifications do
     end
     self.save!
   end
+  
+  private
+  
+  # def notified_users_based_on_mail_message(message)
+  #   recipient_emails = message.to.to_a + message.cc.to_a - notified_users.pluck(:email)
+  #   recipient_emails.collect { |email| User.where(email: email).first_or_create }
+  # end
   
 end

--- a/app/models/concerns/reply_notifications.rb
+++ b/app/models/concerns/reply_notifications.rb
@@ -1,0 +1,36 @@
+concern :ReplyNotifications do
+  
+  included do
+    has_many :notifications, as: :notifiable, dependent: :destroy
+    has_many :notified_users, source: :user, through: :notifications
+  end
+  
+  def set_default_notifications!
+    unless reply_to_type.nil?
+
+      notified_users = reply_to.notified_users
+      if Tenant.current_tenant.first_reply_ignores_notified_agents? &&
+            reply_to.is_a?(Ticket) &&
+            reply_to.assignee.present?
+        notified_users = [reply_to.assignee]
+      end
+
+      self.notified_users =
+          ([reply_to.user] + notified_users - [user]).uniq
+    else
+      result = []
+      if ticket.assignee.present?
+        result << ticket.assignee
+      else
+        result = User.agents_to_notify
+      end
+
+      ticket.labels.each do |label|
+        result += label.users
+      end
+
+      self.notified_users = result.uniq
+    end
+  end
+  
+end

--- a/app/models/concerns/reply_notifications.rb
+++ b/app/models/concerns/reply_notifications.rb
@@ -14,7 +14,7 @@ concern :ReplyNotifications do
             reply_to.assignee.present?
         notified_users = [reply_to.assignee]
       end
-
+    
       self.notified_users =
           ([reply_to.user] + notified_users - [user]).uniq
     else
@@ -31,6 +31,17 @@ concern :ReplyNotifications do
 
       self.notified_users = result.uniq
     end
+  end
+  
+  def notify_users
+    self.message_id = nil
+    notified_users.each do |user|
+      mail = NotificationMailer.new_reply(self, user)
+      mail.message_id = self.message_id
+      mail.deliver_now unless user.ticket_system_address?
+      self.message_id = mail.message_id
+    end
+    self.save!
   end
   
 end

--- a/app/models/concerns/reply_notifications.rb
+++ b/app/models/concerns/reply_notifications.rb
@@ -115,11 +115,18 @@ concern :ReplyNotifications do
     has_many :notified_users, source: :user, through: :notifications
   end
   
-  def set_default_notifications!
+  def set_default_notifications!(mail_message = nil)
     unless reply_to_type.nil?
       
       self.notified_users = users_to_notify_based_on_ticket_assignment
-      self.notified_users = users_to_notify_based_on_former_reply if self.notified_users.none?
+      
+      if self.notified_users.none?
+        if mail_message && user && user.client?
+          self.notified_users = users_to_notify_based_on_former_reply.where(agent: true)  # (2)(b)(i)
+        else
+          self.notified_users = users_to_notify_based_on_former_reply  # (1)(a)(i), (2)(a)(i), (1)(b)(i)
+        end
+      end
       
       self.notified_users.uniq!
 

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -46,7 +46,7 @@ class Reply < ActiveRecord::Base
   }
 
   def reply_to
-    reply_to_type.constantize.where(id: self.reply_to_id).first
+    reply_to_type.constantize.where(id: self.reply_to_id).first if reply_to_type
   end
 
   def reply_to=(value)
@@ -56,5 +56,9 @@ class Reply < ActiveRecord::Base
 
   def other_replies
     ticket.replies.where.not(id: id)
+  end
+  
+  def first?
+    reply_to_type == 'Ticket'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ActiveRecord::Base
   has_many :labels, through: :labelings
   has_many :assigned_tickets, class_name: 'Ticket',
       foreign_key: 'assignee_id', dependent: :nullify
+  has_many :notifications    
 
   # identities for omniauth
   has_many :identities
@@ -65,6 +66,29 @@ class User < ActiveRecord::Base
   def self.agents_to_notify
     User.agents
         .where(notify: true)
+  end
+
+  # Does the email address of this user belong to the ticket system
+  # itself? For example, there might be a user corresponding to
+  # support@example.com.
+  #
+  # This check is needed to prevent email loops. We do not want to
+  # deliver to those email addresses, since they would be received
+  # by the ticket system, again, creating an email loop.
+  #
+  def ticket_system_address?
+    User.ticket_system_addresses.pluck(:id).include? self.id
+  end
+
+  # Return all users that correspond to email addresses belonging
+  # to the ticket system, e.g. support@example.com.
+  #
+  def self.ticket_system_addresses
+    User.where(email: EmailAddress.pluck(:email))
+  end
+  
+  def client?
+    not agent?
   end
 
   def default_localization

--- a/app/views/replies/_reply.html.erb
+++ b/app/views/replies/_reply.html.erb
@@ -38,16 +38,7 @@
         <% end %>
 
         <hr />
-        <ul class="inline-list text-secondary no-mb">
-          <% if reply.notified_users.count > 0 %>
-            <li><%= t(:notification_sent_to) %></li>
-            <% reply.notified_users.each do |user| %>
-              <li><%= user.email %></li>
-            <% end %>
-          <% else %>
-            <li class="no-ml"><%= t(:no_notifications_sent) %></li>
-          <% end %>
-        </ul>
+        <%= render partial: 'shared/notified_users_list', locals: {reply: reply} %>
     </div>
   </li>
 </ul>

--- a/app/views/shared/_notified_users_list.html.erb
+++ b/app/views/shared/_notified_users_list.html.erb
@@ -1,0 +1,26 @@
+<%
+  reply_or_ticket ||=   
+  (reply if defined?(reply)) || 
+  (ticket if defined?(ticket)) ||
+  raise('no reply or ticket given') 
+%>
+
+<ul class="inline-list text-secondary no-mb">
+  <% if reply_or_ticket.notified_users.count > 0 %>
+    <li><%= t(:notification_sent_to) %></li>
+
+    <% reply_or_ticket.notified_users.where(agent: false).each do |user| %>
+      <li><%= link_to(user.email, user_tickets_path(user_id: user.id)) %></li>
+    <% end %>
+
+    <% if reply_or_ticket.notified_users.where(agent: true).any? %>
+      <li><strong><%= t(:agents) %>:</strong></li>
+      <% reply_or_ticket.notified_users.where(agent: true).each do |user| %>
+        <li><%= link_to(user.email, user_tickets_path(user_id: user.id)) %></li>
+      <% end %>
+    <% end %>
+
+  <% else %>
+    <li class="no-ml"><%= t(:no_notifications_sent) %></li>
+  <% end %>
+</ul>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -119,13 +119,7 @@
         <% end %>
 
         <hr />
-        <ul class="inline-list text-secondary no-mb">
-          <li><%= t(:notification_sent_to) %></li>
-          <% @ticket.notified_users.each do |user| %>
-            <li><%= user.email %></li>
-          <% end %>
-        </ul>
-
+        <%= render partial: 'shared/notified_users_list', locals: {ticket: @ticket} %>
 
         <% if @ticket.attached_files.size > 0 %>
           <hr />

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,10 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  
+  # Open emails in the browser.
+  # https://github.com/ryanb/letter_opener
+  config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -146,6 +146,7 @@ de:
   email: E-Mail-Adresse
   role: Rolle
   agent: Agent
+  agents: Agenten
   customer: Kunde
 
 # users/_form

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -112,6 +112,8 @@ de:
   send_reply: Anwort senden
   on_date_author_wrote: 'Am %{date} hat %{author} folgendes geschrieben:'
   notification_will_be_sent_to: 'Es wird eine Benachrichtung an folgende Adresse gesendet:'
+  save_as_draft: Als Entwurf speichern
+  internal_note: Interne Notiz
 
 # ticket_mailer/notify_assigned.text.erb
   ticket_assigned: Ihnen wurde ein Ticket zugewiesen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,7 @@ en:
   email: Email
   role: Role
   agent: Agent
+  agents: Agents
   customer: Customer
 
 # users/_form

--- a/test/controllers/replies_controller_test.rb
+++ b/test/controllers/replies_controller_test.rb
@@ -106,7 +106,7 @@ class RepliesControllerTest < ActionController::TestCase
       }
     end
     mail = ActionMailer::Base.deliveries.last
-    assert_equal [users(:alice).email], mail.to
+    assert_equal users(:alice).email, mail.header_fields.select { |field| field.name == 'smtp-envelope-to' }.last.value
   end
 
   test 'should re-open ticket' do

--- a/test/models/reply_test.rb
+++ b/test/models/reply_test.rb
@@ -113,5 +113,18 @@ class ReplyTest < ActiveSupport::TestCase
     assert reply_of_client2.notified_users.include?(agent)
     assert not(reply_of_client2.notified_users.include?(client1))
   end
+  
+  test 'should sync the message ids of notifications' do
+    ticket = tickets(:daves_problem)
+    reply = ticket.replies.create user: users(:alice), content: "This is the solution."
+    reply.notified_users << users(:dave)
+    reply.notified_users << users(:bob)
+    
+    message_ids = reply.notification_mails.map(&:message_id)
+    assert_equal message_ids.count,  2
+    assert_equal message_ids.uniq.count, 1
+    refute_equal message_ids.first, ""
+    refute_equal message_ids.first, nil
+  end
 
 end

--- a/test/models/reply_test.rb
+++ b/test/models/reply_test.rb
@@ -72,4 +72,46 @@ class ReplyTest < ActiveSupport::TestCase
     assert reply.notified_users.include?(users(:charlie))
   end
 
+  test 'should not notify other clients when one of the clients replies' do
+    #
+    # Suppose, several clients are part of a conversation. Now, one of the
+    # clients replies to something an agent wrote and only answers to the
+    # email address of the ticket system, e.g. support@example.com.
+    #
+    # The other clients that are part of this conversation should not be
+    # notified, since the sender can't see that they would receive this
+    # email.
+    #
+    # See also: https://github.com/ivaldi/brimir/issues/259
+    #
+    agent = User.create! email: 'agent@example.com', agent: true
+    client1 = User.create! email: 'client1@example.com'
+    client2 = User.create! email: 'client2@example.com'
+    
+    # client1 creates a ticket via email.
+    ticket = Ticket.create from: 'client1@example.com', content: 'This is my problem'
+    
+    # agent replies via the web ui of brimir.
+    reply_of_the_agent = ticket.replies.create! content: 'This might be the solution. It did work for client2 who also works in your office.', user: agent
+    reply_of_the_agent.notified_users << client1
+    reply_of_the_agent.notified_users << client2
+    
+    # client1 replies via email; cc to client2.
+    reply_of_client1 = ticket.replies.create! content: 'It did not work.', user: client1
+    reply_of_client1.reply_to = reply_of_the_agent
+    reply_of_client1.set_default_notifications!("From: client1@example.com\nTo: ...")
+    reply_of_client1.notified_users << client2 unless reply_of_client1.notified_users.include? client2
+    
+    assert reply_of_client1.notified_users.include?(agent)
+    assert reply_of_client1.notified_users.include?(client2)
+
+    # client2 replies via email, but not cc to client1.
+    reply_of_client2 = ticket.replies.create! content: 'client1 is stupid! Did he even start his computer?', user: client2
+    reply_of_client2.reply_to = reply_of_the_agent
+    reply_of_client2.set_default_notifications!("From: client2@example.com\nTo: ...")
+    
+    assert reply_of_client2.notified_users.include?(agent)
+    assert not(reply_of_client2.notified_users.include?(client1))
+  end
+
 end


### PR DESCRIPTION
This pull request solves https://github.com/ivaldi/brimir/issues/259.

While brimir always stores recipients in `reply#notified_users`, it is not always responsible to deliver these notifications. (https://github.com/ivaldi/brimir/commit/3f05af8905dce36fed9b3c39e408cd5fc4ff2846)

<img width="672" alt="bildschirmfoto 2016-03-17 um 23 36 50" src="https://cloud.githubusercontent.com/assets/1679688/13863676/d2b42b2e-ec9b-11e5-9169-6dc7fe07e460.png">

Instead, include the other clients in the `To` field when replying to a client to allow the client to send his reply explicitly to other clients or to refrain from doing so. (https://github.com/ivaldi/brimir/commit/fb3025e0e0a53dc5edf1a939e8d8634006bdac48)

## Considerations

### How is the reply sent?

**(1) The user may reply via the web ui of brimir.**

   - The ticket system suggests recipients based on the former
     conversation.
   - The user can change the recipients in the web form before
     sending the reply.

**(2) The user may reply via email to support@example.com.**

  - The ticket system has to determine who, at least, needs to
    be notified, since the user just writes to support@example.com,
    not to the separate clients or agents.
  - The user might add additional recipients by including them
    in the `To`, `CC` or `BCC` fields in the email client.


### Who is sending the reply?

**(a) The reply author can be an agent.**

  - Agents can reply to agents and clients via email to
    support@example.com.
  - This mechanism mainly is a convenience shortcut if there is
    only one possible recipient, i.e. the client that
    asked the question.

**(b) The reply author can be a client.**

  - Clients can only reply to agents via email to
    support@example.com.
  - This is to make sure that it is always transparent
    who will get the reply.
  - If they need to add other recipients, they can add them
    in the `To`, `CC` or `BCC` field.


### Who is added to `notified_users`?

The association `Reply#notified_users` saves who has been notified
about a certain reply.

**(i) Users that have received a notification through brimir.**
      These can be agents or clients.

**(ii) Users that are listed in `To` or `CC`** when the reply created
      via email. These notifications are not sent by brimir,
      since these recipients receive emails directly from the
      sender.


### Who will be notified by brimir?

**(a) If the reply author is an agent:**

  The agent always sends replies through the ticket system, either
  through the web ui (1) or via email to support@example.com (2).
  Thus, the ticket system is responsible to deliver the reply to the
  recipients.

  ⇒ Send notifications to agents and clients. (1)(a)(i), (2)(a)(i)

**(b) If the reply author is a client:**

* (1) Through the web ui, there is no sending email client involved.

  ⇒ Send notifications to agents and clients. (1)(b)(i)

* (2) Via email to support@example.com, the clients explicitly sends
         to other clients using the `To`, `CC`, `BCC` fields of his email
         client. Thus, the ticket system is only responsible to deliver
         to the agents.

    ⇒ Send notifications only to agents. (2)(b)(i)


### Who will be listed in `To`, who in `BCC`?

 - (a) In emails to clients, agents are never listed as `To`
         in order not to reveal the private email addresses
         of the agents.

 - (b) In emails to clients, other client-recipients' email addresses
         are listed in `To`. This way, the clients can include
         the other recipients in their replies intentionally.

In order to distinguish notifications that are to be delivered through brimir and notifications that are already sent, the other recipients from the `original_message` are added after `reply#notify_users` in the [NotificationMailer](https://github.com/fiedl/brimir/blob/3f05af8905dce36fed9b3c39e408cd5fc4ff2846/app/mailers/notification_mailer.rb#L25L67).


### Why is this important.

For an example test case, see:
  [ReplyTest#test_should_not_notify_other_clients_when_one_of_the_clients_replies,  test/models/reply_test.rb](https://github.com/ivaldi/brimir/compare/master...fiedl:sf/259-notifications?expand=1#diff-56a15b0c989c4a93a20965dd638478f0R75)

The issue is discussed on github:
https://github.com/ivaldi/brimir/issues/259

## Notable changes

* (https://github.com/ivaldi/brimir/commit/fb3025e0e0a53dc5edf1a939e8d8634006bdac48) **notification mailer: Include other clients in the `To` email field.**

  To allow clients to choose to which other clients they would like to
  reply, include other clients in the `To` email field.
  
  Agents are not included in the `To` email field to prevent their
  personal email addresses from becoming public.
* (https://github.com/ivaldi/brimir/commit/3f05af8905dce36fed9b3c39e408cd5fc4ff2846) **Do not notify other clients silently, when a client replies via email.**