### PR TITLE
Log smtp-envelope-to in `Mail::Message#deliver`.

### DIFF
--- a/app/models/mail_message_extension.rb
+++ b/app/models/mail_message_extension.rb
@@ -1,0 +1,16 @@
+# This is prepended to Mail::Message.
+# https://github.com/mikel/mail/blob/master/lib/mail/message.rb
+#
+module MailMessageExtension
+
+  def deliver
+    Rails.logger.info "Sending mail smtp_envelope_to #{self.smtp_envelope_to.to_s}."
+    return super
+  end
+
+  def smtp_envelope_to
+    (header_fields.select { |field| field.name == 'smtp-envelope-to' }.count <= 1) || raise('There should be only one smtp-envelope-to header field.')
+    header_fields.select { |field| field.name == 'smtp-envelope-to' }.last.try(:value) || super
+  end
+
+end

--- a/config/initializers/mail_message_extension.rb
+++ b/config/initializers/mail_message_extension.rb
@@ -1,0 +1,3 @@
+require 'mail'
+
+Mail::Message.send(:prepend, MailMessageExtension)


### PR DESCRIPTION
Discussion in https://github.com/ivaldi/brimir/issues/279.

When delivering emails, usually the `To` field is logged. Log files contain a line like "Sent mail to customer@domain.com (49.8ms)". With this pull request, also the `smtp-envelope-to` will be logged: "Sending mail smtp_envelope_to foo@example.com."

I also added the convenience method `Mail::Message#smtp_envelope_to` that reads out the corresponding header field. Usually one would have to use `Mail::Message#header_fields.select { |field| field.name == 'smtp-envelope-to' }`.