### PR TITLE
Fix multiple-notifications issue #279.

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -103,11 +103,14 @@ class NotificationMailer < ActionMailer::Base
     @reply = reply
     @user = user
     return if EmailAddress.pluck(:email).include?(user.email.to_s)
-    
+
     displayed_to_field = reply.notified_users.where(agent: false).pluck(:email)
     displayed_to_field = user.email if displayed_to_field.empty?
-    mail(smtp_envelope_to: user.email, to: displayed_to_field,
+
+    message = mail(smtp_envelope_to: user.email, to: displayed_to_field,
       subject: title, from: reply.ticket.reply_from_address)
+    message.smtp_envelope_to = user.email
+    return message
   end
 
   def status_changed(ticket)

--- a/test/controllers/replies_controller_test.rb
+++ b/test/controllers/replies_controller_test.rb
@@ -106,7 +106,7 @@ class RepliesControllerTest < ActionController::TestCase
       }
     end
     mail = ActionMailer::Base.deliveries.last
-    assert_equal users(:alice).email, mail.header_fields.select { |field| field.name == 'smtp-envelope-to' }.last.value
+    assert_equal [users(:alice).email], mail.smtp_envelope_to
   end
 
   test 'should re-open ticket' do


### PR DESCRIPTION
Setting `Mail::Message#smtp_envelope_to=...` directly in addition to passing it to `ActionMailer::Base#mail`.

This fixes https://github.com/ivaldi/brimir/issues/279.

I've just applied this to our production instance. Works fine.

See also:

* https://github.com/ivaldi/brimir/issues/279#issuecomment-233597676
* https://github.com/mikel/mail/issues/1015