### PR TITLE
Attachment and raw message issues for merged tickets

### DIFF
--- a/app/models/concerns/merged_reply.rb
+++ b/app/models/concerns/merged_reply.rb
@@ -1,0 +1,44 @@
+# This module concerns Replies.
+# Replies can be `merged?`, i.e. be copies of Tickets or other Replies
+# after merging tickets.
+#
+# Raw messages and attachments are not copied when merigng. Thus, we
+# need to redirect calls to `raw_message` and `attachments` to the
+# original object.
+#
+# Attention! This module needs to be prepended, not included. This is
+# because carrierwave defines the `raw_message` method using `define_method`.
+# The method override in this module is just ignored if the module is
+# included due to the lookup order for methods.
+# See also: https://www.ruby-forum.com/topic/195231
+#
+concern :MergedReply do
+
+  def result_of_merge?
+    true if original_ticket_or_reply_before_merge
+  end
+
+  def original_ticket_or_reply_before_merge
+    if message_id
+      @original_ticket_or_reply_before_merge ||= Ticket.merged.where(message_id: message_id).first || Reply.where(message_id: message_id).where('id < ?', id).first
+    end
+  end
+
+  def attachments
+    original_ticket_or_reply_before_merge.try(:attachments) || super
+  end
+
+  def raw_message
+    if super.try(:path, :original) && File.file?(super.path(:original))
+      super
+    elsif original_ticket_or_reply_before_merge.try(:raw_message?)
+      original_ticket_or_reply_before_merge.raw_message
+    else
+      super
+    end
+  end
+
+  def raw_message?
+    raw_message.try(:path, :original) && File.file?(raw_message.path(:original))
+  end
+end

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -19,6 +19,7 @@ class Reply < ActiveRecord::Base
   include CreateFromUser
   include EmailMessage
   include ReplyNotifications
+  prepend MergedReply
 
   attr_accessor :reply_to_id
   attr_accessor :reply_to_type


### PR DESCRIPTION
We've experienced some issues with merged tickets: After merging a ticket, we **neither can access the attachments nor the raw message through the merged record**.

This pull request will:

* [x] provide a spec for the issue: https://github.com/ivaldi/brimir/pull/287/commits/5063cb462f1a6d7ecd25e242ba2fcba1e28f41bf
* [x] solve the issue: https://github.com/ivaldi/brimir/pull/287/commits/19804c981417d4b73bc84355b8d310304c8d5234

### Remarks

* We already had specs for merging ticket with attachments, but these didn't check whether the attachment and raw message files of the duplicates exist on the file system. Due to the lack of my understanding of [paperclip](https://github.com/thoughtbot/paperclip), I did not realize that duplicating the record would neither duplicate the uploaded file nor link the new record correctly to the old file.
* The fix works retroactively, i.e. when merging the pull request, the fix applies also to tickets merged in the past.
* The fix overrides the `attachments` and `raw_message` methods in a way that also tries to get the file from the original (before merge) object, which is identified by its message id.