### PR TITLE
Fixes an issue with Gravatar tag breaking

### DIFF
--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -101,6 +101,7 @@ module AvatarHelper
   private
 
   def user_gravatar(user, options = {})
+    options[:size] = options[:size].to_s if options[:size]
     options[:gravatar] ||= {}
     options[:gravatar][:size] ||= options[:size] if options[:size]
     gravatar_image_tag(user.email, gravatar_default_options.deep_merge(options))


### PR DESCRIPTION
Rails 4.2.7 introduced an XSS fix to the `tag` method (rails/rails@f05af91c68debc0230c302aa9031a253f8786b87) which breaks the Gravatar size (as it's an integer). This changes the size to a string.