### PR TITLE
Fix the translation of the status column

### DIFF
--- a/app/views/tickets/index.csv.erb
+++ b/app/views/tickets/index.csv.erb
@@ -20,7 +20,7 @@
         ticket.id,
         '"' + ticket.subject.gsub(/"/, '""') + '"',
         t(ticket.priority),
-        t(ticket.status),
+        t(ticket.status, scope: 'activerecord.attributes.ticket.statuses'),
         (ticket.assignee.email unless ticket.assignee.nil?),
         '"' + l(ticket.created_at.in_time_zone(current_user.time_zone), format: :long).gsub(/"/, '""') + '"',
         status_times[:open].round(1),


### PR DESCRIPTION
This fixes the Status column in the CSV export (as mentioned in issue #283), based on comments in PR #291 