### PR TITLE
Captcha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,6 @@ gem 'fancybox2-rails', '~> 0.2.8'
 
 # gravatar for user avatar images
 gem 'gravatar_image_tag'
+
+# Captcha for brimir
+gem "recaptcha", require: "recaptcha/rails"

--- a/Gemfile
+++ b/Gemfile
@@ -86,4 +86,4 @@ gem 'fancybox2-rails', '~> 0.2.8'
 gem 'gravatar_image_tag'
 
 # Captcha for brimir
-gem "recaptcha", require: "recaptcha/rails"
+gem 'recaptcha', require: 'recaptcha/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,8 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    recaptcha (3.3.0)
+      json
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     sass (3.4.22)
@@ -283,6 +285,7 @@ DEPENDENCIES
   rails (~> 4.2.0)
   rails-i18n
   rake
+  recaptcha
   sass-rails (~> 5.0.0)
   select2-rails (~> 3.5)
   spring

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ If you want to use LDAP, configure config/ldap.yml accordingly, then change the 
     bin/rails console production
     u = User.new({ email: 'your@email.address', password: 'somepassword', password_confirmation: 'somepassword' }); u.agent = true; u.save!
 
-IMPORTANT Captcha Notice:
+Configuring Captcha's
+---------------------
 If you want to use recaptcha in production you have to go to
 https://www.google.com/recaptcha, create your private and public keys and export these to your production environment, by running:
 
     export RECAPTCHA_PUBLIC_KEY="[YOUR_KEY]"
-    export RECAPTCHA_PRIVATE_KEY="["YOUR_KEY"]"
+    export RECAPTCHA_PRIVATE_KEY="[YOUR_KEY]"
 
 Updating
 --------

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ If you want to use LDAP, configure config/ldap.yml accordingly, then change the 
     bin/rails console production
     u = User.new({ email: 'your@email.address', password: 'somepassword', password_confirmation: 'somepassword' }); u.agent = true; u.save!
 
+IMPORTANT Captcha Notice:
+If you want to use recaptcha in production you have to go to
+https://www.google.com/recaptcha, create your private and public keys and export these to your production environment, by running:
+
+    export RECAPTCHA_PUBLIC_KEY="[YOUR_KEY]"
+    export RECAPTCHA_PRIVATE_KEY="["YOUR_KEY"]"
+
 Updating
 --------
 First download the new code in the same directory by unpacking a release tarball or by running `git pull` (when you cloned the repo earlier). After updating code run the following commands to install necessary gem updates, migrate the database and regenerate precompiled assets.
@@ -107,7 +114,6 @@ Some users have made requests for the following features. If you would like to c
 - Desktop notifications using web notifications (#218).
 - Custom ticket statuses, all via database. (#217)
 - Filter on to/cc/bcc without verified addresses. (#227)
-- Add captcha for non-signed in ticket creation. (#228)
 - IMAP or POP3 pull mechanism for new tickets. (#249)
 - Notes field for customer account, to add info about them, such as website url.
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -165,12 +165,8 @@ class Ticket < ActiveRecord::Base
   end
 
   def self.recaptcha_keys_present?
-    if Recaptcha.configuration.public_key.blank? &&
-        Recaptcha.configuration.private_key.blank?
-      false
-    else
-      true
-    end
+    !Recaptcha.configuration.public_key.blank? ||
+      !Recaptcha.configuration.private_key.blank?
   end
 
   protected

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -164,6 +164,15 @@ class Ticket < ActiveRecord::Base
     to_email_address.try :email
   end
 
+  def self.recaptcha_keys_present?
+    if Recaptcha.configuration.public_key.blank? &&
+        Recaptcha.configuration.private_key.blank?
+      false
+    else
+      true
+    end
+  end
+
   protected
     def create_status_change
       status_changes.create! status: self.status

--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -54,6 +54,12 @@
 
   <%= render 'attachments/form', f: f %>
 
+  <% if Ticket.recaptcha_keys_present? %>
+    <p>
+      <%= recaptcha_tags %>
+    </p>
+  <% end %>
+
   <p>
     <%= f.submit class: 'button regular radius' %>
   </p>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,14 @@
+# these will only work locally 
+# Create your own at https://www.google.com/recaptcha
+
+if Rails.env == "production"
+  Recaptcha.configure do |config|
+    config.public_key   = Rails.application.secrets[:recaptcha_public_key]
+    config.private_key  = Rails.application.secrets[:recaptcha_private_key]
+  end
+else
+  Recaptcha.configure do |config|
+    config.public_key   = Rails.application.secrets[:recaptcha_public_key]
+    config.private_key  = Rails.application.secrets[:recaptcha_private_key]
+  end
+end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,14 +1,7 @@
 # these will only work locally 
 # Create your own at https://www.google.com/recaptcha
 
-if Rails.env == "production"
-  Recaptcha.configure do |config|
-    config.public_key   = Rails.application.secrets[:recaptcha_public_key]
-    config.private_key  = Rails.application.secrets[:recaptcha_private_key]
-  end
-else
-  Recaptcha.configure do |config|
-    config.public_key   = Rails.application.secrets[:recaptcha_public_key]
-    config.private_key  = Rails.application.secrets[:recaptcha_private_key]
-  end
+Recaptcha.configure do |config|
+  config.public_key   = Rails.application.secrets[:recaptcha_public_key]
+  config.private_key  = Rails.application.secrets[:recaptcha_private_key]
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,11 +14,15 @@ development:
   secret_key_base: 2db2964f8fcc1eaebf8db0116a54889c81ea3e7baa83cca54c67c25c6d1b1901a60093e2b9189a40c979fc8b85bf1295c6b2a3e86fbdbe2464f5cf02fd306007
   google_client_id: 1032949297619-5nqftn8e540bnohtqjiv3pg2qvg7uvtj.apps.googleusercontent.com
   google_client_secret: 1L43_SExBR35OHLi4jnLOkzr
+  recaptcha_public_key: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+  recaptcha_private_key: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 
 test:
   secret_key_base: e1dd1f2fa691750f01e19de0ab7066263251d06a3c4a33ab5dfa6ab0500cd4911ab9e53c118587e91ccd9577dacb13b00b70692c79fc3818ee09a9395d372b3c
   google_client_id:
   google_client_secret:
+  recaptcha_public_key: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+  recaptcha_private_key: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
@@ -26,3 +30,5 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   google_client_id:
   google_client_secret:
+  recaptcha_public_key:  <%= ENV["RECAPTCHA_PUBLIC_KEY"] %>
+  recaptcha_private_key: <%= ENV["RECAPTCHA_PRIVATE_KEY"] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 20160615124420) do
     t.string   "default_locale",                                  default: "en"
     t.boolean  "share_drafts",                                    default: false
     t.boolean  "first_reply_ignores_notified_agents",             default: false,       null: false
-    t.boolean  "notify_client_when_ticket_is_assigned_or_closed", default: false
+    t.boolean  "notify_client_when_ticket_is_assigned_or_closed", default: false,       null: false
   end
 
   add_index "tenants", ["domain"], name: "index_tenants_on_domain", unique: true

--- a/test/controllers/tickets_controller_test.rb
+++ b/test/controllers/tickets_controller_test.rb
@@ -76,9 +76,9 @@ class TicketsControllerTest < ActionController::TestCase
     assert_no_difference 'ActionMailer::Base.deliveries.size' do
       assert_no_difference 'Ticket.count' do
         post :create, ticket: {
-            from: 'invalid',
-            content: '',
-            subject: '',
+          from: 'invalid',
+          content: '',
+          subject: '',
         }
 
         assert_response :success
@@ -93,9 +93,9 @@ class TicketsControllerTest < ActionController::TestCase
     assert_difference 'ActionMailer::Base.deliveries.size', User.agents.count do
       assert_difference 'Ticket.count' do
         post :create, ticket: {
-            from: 'test@test.nl',
-            content: @ticket.content,
-            subject: @ticket.subject,
+          from: 'test@test.nl',
+          content: @ticket.content,
+          subject: @ticket.subject,
         }
 
         assert_response :success
@@ -111,9 +111,9 @@ class TicketsControllerTest < ActionController::TestCase
     assert_difference 'ActionMailer::Base.deliveries.size', User.agents.count do
       assert_difference 'Ticket.count', 1 do
         post :create, ticket: {
-            from: 'test@test.nl',
-            content: @ticket.content,
-            subject: @ticket.subject,
+          from: 'test@test.nl',
+          content: @ticket.content,
+          subject: @ticket.subject,
         }
 
         assert_redirected_to ticket_url(assigns(:ticket))
@@ -166,7 +166,7 @@ class TicketsControllerTest < ActionController::TestCase
 
     # should have selected same outgoing address as original received
     assert_select 'option[selected="selected"]' +
-        "[value=\"#{email_addresses(:brimir).id}\"]"
+      "[value=\"#{email_addresses(:brimir).id}\"]"
 
     # should contain this for internal note switch
     assert_select '[data-notified-users]'
@@ -317,6 +317,32 @@ class TicketsControllerTest < ActionController::TestCase
         assert_response :unprocessable_entity
 
       end
+    end
+  end
+
+  test 'shown captcha should not break new ticket page when not signed in' do
+    # Stub keys Recaptcha
+    Recaptcha.configuration.public_key = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+    Recaptcha.configuration.private_key = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
+
+    if Ticket.recaptcha_keys_present?
+
+      get :new
+
+      assert_response :success
+    end
+  end
+
+  test 'not shown captcha should not break new ticket page when not signed' do
+    # Stub keys Recaptcha
+    Recaptcha.configuration.public_key = ''
+    Recaptcha.configuration.private_key = ''
+
+    if !(Ticket.recaptcha_keys_present?)
+
+      get :new
+
+      assert_response :success
     end
   end
 

--- a/test/controllers/tickets_controller_test.rb
+++ b/test/controllers/tickets_controller_test.rb
@@ -76,9 +76,9 @@ class TicketsControllerTest < ActionController::TestCase
     assert_no_difference 'ActionMailer::Base.deliveries.size' do
       assert_no_difference 'Ticket.count' do
         post :create, ticket: {
-          from: 'invalid',
-          content: '',
-          subject: '',
+            from: 'invalid',
+            content: '',
+            subject: '',
         }
 
         assert_response :success
@@ -93,9 +93,9 @@ class TicketsControllerTest < ActionController::TestCase
     assert_difference 'ActionMailer::Base.deliveries.size', User.agents.count do
       assert_difference 'Ticket.count' do
         post :create, ticket: {
-          from: 'test@test.nl',
-          content: @ticket.content,
-          subject: @ticket.subject,
+            from: 'test@test.nl',
+            content: @ticket.content,
+            subject: @ticket.subject,
         }
 
         assert_response :success
@@ -111,9 +111,9 @@ class TicketsControllerTest < ActionController::TestCase
     assert_difference 'ActionMailer::Base.deliveries.size', User.agents.count do
       assert_difference 'Ticket.count', 1 do
         post :create, ticket: {
-          from: 'test@test.nl',
-          content: @ticket.content,
-          subject: @ticket.subject,
+            from: 'test@test.nl',
+            content: @ticket.content,
+            subject: @ticket.subject,
         }
 
         assert_redirected_to ticket_url(assigns(:ticket))
@@ -166,7 +166,7 @@ class TicketsControllerTest < ActionController::TestCase
 
     # should have selected same outgoing address as original received
     assert_select 'option[selected="selected"]' +
-      "[value=\"#{email_addresses(:brimir).id}\"]"
+        "[value=\"#{email_addresses(:brimir).id}\"]"
 
     # should contain this for internal note switch
     assert_select '[data-notified-users]'
@@ -321,10 +321,6 @@ class TicketsControllerTest < ActionController::TestCase
   end
 
   test 'shown captcha should not break new ticket page when not signed in' do
-    # Stub keys Recaptcha
-    Recaptcha.configuration.public_key = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
-    Recaptcha.configuration.private_key = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
-
     if Ticket.recaptcha_keys_present?
 
       get :new
@@ -334,7 +330,6 @@ class TicketsControllerTest < ActionController::TestCase
   end
 
   test 'not shown captcha should not break new ticket page when not signed' do
-    # Stub keys Recaptcha
     Recaptcha.configuration.public_key = ''
     Recaptcha.configuration.private_key = ''
 


### PR DESCRIPTION
When creating new tickets as a non signed in user, this will add a captcha above the submit button.
To use the captcha two keys are needed:

```
RECAPTCHA_PUBLIC_KEY
RECAPTCHA_PRIVATE_KEY
```

These keys are set by the recaptcha.rb file in the config/initializer directory and are read from the secrets.yml file.

This pull request will include two testing keys, but for production a set of keys need to be created at the [official website](https://www.google.com/recaptcha) and exported to the environment directly, like so:

```
export RECAPTCHA_PUBLIC_KEY="[YOUR_KEY]"
export RECAPTCHA_PRIVATE_KEY="[YOUR_KEY]"
```

This pull request also includes an entry about captcha in the README.md and two tests that check for breakage.

This should fix [#228](https://github.com/ivaldi/brimir/issues/228)
