### PR TITLE
Fixed captcha still showing for signed in users

### DIFF
--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -54,7 +54,7 @@
 
   <%= render 'attachments/form', f: f %>
 
-  <% if Ticket.recaptcha_keys_present? %>
+  <% if Ticket.recaptcha_keys_present? && !user_signed_in? %>
     <p>
       <%= recaptcha_tags %>
     </p>


### PR DESCRIPTION
Captcha was still showing for logged in users, even though verification was skipped entirely. This pull request should fix this.