### PR TITLE
Fix for rules not applying on tickets created through a mua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Optional notification of customers when ticket is assigned or status is changed. Contributed by @fiedl.
 - Optional captcha for non-signed in ticket creation. Constributed by @git-jls.
+- Disable captcha check for incoming email posts. Constributed by @git-jls.
+
 ### Changed
 
 ### Deprecated

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -207,7 +207,7 @@ class TicketsController < ApplicationController
 
   def send_notification_email
     # not signed in
-    if current_user.nil?
+    if current_user.nil? && params[:format] != 'json'
       # we need to verify the capthca
       if verify_recaptcha
         # we need to verify the ticket


### PR DESCRIPTION
This request should fix and issue with the the rules being skipped if ticket is created from a message being sent by a MUA.

Issue introduced in 0.7.1-32-g95c6822.