### PR TITLE
Allows adding rules to filter on cc and actual to addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Rule management interface has been improved, making it understandable for more users.
 - Tabindex for a better user experience when filling out ticket forms. Constributed by @git-jls.
+- Allows adding rules to filter on cc and actual to addresses. Constributed by @git-jls.
+
 
 ### Changed
 - Better error messages when an invalid input is given for non-signed in users. Contributed by @mickael-kerjean.

--- a/app/mailers/ticket_mailer.rb
+++ b/app/mailers/ticket_mailer.rb
@@ -85,6 +85,9 @@ class TicketMailer < ActionMailer::Base
     end
 
     from_address = email.from.first
+    # yes this can get really long...
+    to_addresses = email.to.join ',' unless email.to.nil?
+    cc_addresses = email.cc.join ',' unless email.cc.nil?
     unless email.reply_to.blank?
       from_address = email.reply_to.first
     end
@@ -114,6 +117,8 @@ class TicketMailer < ActionMailer::Base
       # add new ticket
       ticket = Ticket.create({
         from: from_address,
+        orig_to: to_addresses,
+        orig_cc: cc_addresses,
         subject: subject,
         content: content,
         message_id: email.message_id,

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="large-6 columns">
       <%
         fields = []
-        [:from, :subject, :content, :orig_to, :orig_cc].each do |key|
+        [:from, :subject, :content, :orig_to, :orig_cc, :to].each do |key|
           fields << [t(key, scope: 'activerecord.attributes.ticket'), key]
         end
       %>

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -3,7 +3,7 @@
     <div class="large-6 columns">
       <%
         fields = []
-        [:from, :subject, :content, :to].each do |key|
+        [:from, :subject, :content, :orig_to, :orig_cc].each do |key|
           fields << [t(key, scope: 'activerecord.attributes.ticket'), key]
         end
       %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,7 +290,8 @@ en:
         priority: Priority
         assignee_id: Assignee
         created_at: Created at
-        to: To email address
+        orig_to: To email address
+        orig_cc: CC email address
 
       reply:
         from: From email address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,7 @@ en:
         priority: Priority
         assignee_id: Assignee
         created_at: Created at
+        to: To verified email address
         orig_to: To email address
         orig_cc: CC email address
 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -283,6 +283,7 @@ nl:
         priority: Prioriteit
         assignee_id: Toegewezen aan
         created_at: Aangemaakt op
+        to: Aan gevalideerd e-mailadres
         orig_to: Aan e-mailadres
         orig_cc: CC e-mailadres
 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -283,7 +283,8 @@ nl:
         priority: Prioriteit
         assignee_id: Toegewezen aan
         created_at: Aangemaakt op
-        to: Aan e-mailadres
+        orig_to: Aan e-mailadres
+        orig_cc: CC e-mailadres
 
       reply:
         from: Van e-mailadres

--- a/db/migrate/20161122124911_add_to_cc_to_tickets.rb
+++ b/db/migrate/20161122124911_add_to_cc_to_tickets.rb
@@ -1,0 +1,6 @@
+class AddToCcToTickets < ActiveRecord::Migration
+  def change
+    add_column :tickets, :orig_to, :string
+    add_column :tickets, :orig_cc, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -138,7 +138,7 @@ ActiveRecord::Schema.define(version: 20161125000749) do
     t.boolean  "notify_user_when_account_is_created",             default: false
     t.boolean  "notify_client_when_ticket_is_created",            default: false
     t.integer  "email_template_id"
-    t.boolean  "ticket_creation_is_open_to_the_world",            default: true
+    t.boolean  "ticket_creation_is_open_to_the_world"
   end
 
   add_index "tenants", ["domain"], name: "index_tenants_on_domain", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -162,6 +162,8 @@ ActiveRecord::Schema.define(version: 20161125000749) do
     t.string   "raw_message_content_type"
     t.integer  "raw_message_file_size"
     t.datetime "raw_message_updated_at"
+    t.string   "orig_to"
+    t.string   "orig_cc"
   end
 
   add_index "tickets", ["assignee_id"], name: "index_tickets_on_assignee_id"

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -64,7 +64,7 @@ class RuleTest < ActiveSupport::TestCase
 
         Rule.apply_all @ticket
 
-        assert_includes @ticket.labels.collect{|l| l.name}, label
+        assert_includes @ticket.labels.collect{|l| l.name.downcase}, label
       end
     end
   end

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -1,21 +1,147 @@
 require 'test_helper'
 
 class RuleTest < ActiveSupport::TestCase
-  test 'should set priority correctly' do
-    Rule.create filter_field: 'from',
-        filter_value: '@',
-        filter_operation: 'contains',
-        action_operation: 'change_priority',
-        action_value: 'high'
 
-    ticket = Ticket.create from: 'test@test.nl',
-        content: 'problem'
-
-    assert_equal 'unknown', ticket.priority
-
-    Rule.apply_all(ticket)
-
-    assert_equal 'high', ticket.priority
-
+  setup do
+    @filters = [:from, :subject, :content, :orig_to, :orig_cc]
+    @rule = Rule.create({
+      filter_field: 'from',
+      filter_value: '@',
+      filter_operation: 'contains',
+      action_operation: 'change_priority', # field can't be empty so default to this
+      action_value: 'unknown' # field can't be empty so default to this
+    })
+    @ticket = Ticket.create({
+      from: 'test@test.nl',
+      orig_cc: 'dummy2@example.com, dummy3@example.com',
+      orig_to: 'support@ivaldi.nl',
+      content: 'problem'
+    })
   end
+
+  test 'should set priority correctly' do
+    priorities = Ticket.priorities.keys
+    # we test this action
+    @rule.update_attribute(:action_operation, 'change_priority')
+
+    priorities.each do |priority|
+      # default the ticket priority for each iteration
+      @ticket.update_attribute(:priority, 'unknown')
+
+      # use same rule only test for different action_value
+      @rule.update_attribute(:action_value, priority)
+
+      # check if the ticket priority is reset to default
+      assert_equal 'unknown', @ticket.priority
+
+      @filters.each do |filter|
+        @rule.update_attribute(:filter_field, filter)
+        Rule.apply_all @ticket
+      end
+
+      # priority should be changed
+      assert_equal priority, @ticket.priority
+    end
+  end
+
+  test 'should set labels' do
+    labels = ["bug", "change-request", "feature-request", "feedback"]
+    # we test this action
+    @rule.update_attribute(:action_operation, 'assign_label')
+
+    labels.each do |label|
+      #empty the labels collection for each iteration
+      @ticket.update_attribute(:labels, [])
+
+      # use same rule only test for different action_value
+      @rule.update_attribute(:action_value, label)
+
+      # check if the ticket labels are reset to default
+      assert @ticket.labels.empty?
+
+      @filters.each do |filter|
+        @rule.update_attribute(:filter_field, filter)
+
+        Rule.apply_all @ticket
+
+        assert_includes @ticket.labels.collect{|l| l.name}, label
+      end
+    end
+  end
+
+  test 'should assign user' do
+    dummy = User.create({
+      email: 'dummy@example.com',
+      agent: true,
+      name: "dummy",
+      signature: 'Greets, Dummy',
+      authentication_token: 'blabla',
+      notify: true
+    })
+    # we test this action
+    @rule.update_attribute(:action_operation, 'assign_user')
+
+    # use same rule only test for different action_value
+    @rule.update_attribute(:action_value, dummy.email)
+
+    # check default ticket assignee
+    assert_nil @ticket.assignee
+
+    @filters.each do |filter|
+      @rule.update_attribute(:filter_field, filter)
+      Rule.apply_all @ticket
+
+      assert_equal @ticket.assignee, dummy
+    end
+  end
+
+  test 'should add statuses' do
+    statuses = Ticket.statuses.keys
+    # we test this action
+    @rule.update_attribute(:action_operation, 'change_status')
+
+    statuses.each do |status|
+      # default the ticket status for each iteration
+      @ticket.update_attribute(:status, statuses[0])
+
+      # use same rule only test for different action_value
+      @rule.update_attribute(:action_value, status)
+
+      # check if ticket status is reset to default
+      assert_equal statuses[0], @ticket.status
+
+      @filters.each do |filter|
+        @rule.update_attribute(:filter_field, filter)
+        Rule.apply_all @ticket
+
+        assert_equal status, @ticket.status
+      end
+    end
+  end
+
+  test 'should set notify user' do
+    dummy = User.create({
+      email: 'dummy@example.com',
+      agent: true,
+      name: "dummy",
+      signature: 'Greets, Dummy',
+      authentication_token: 'blabla',
+      notify: true
+    })
+    # we test this action
+    @rule.update_attribute(:action_operation, 'notify_user')
+    # use same rule only test for different action_value
+    @rule.update_attribute(:action_value, dummy.email)
+
+    # check the ticket notified_users collection
+    assert @ticket.notified_users.empty?
+
+    @filters.each do |filter|
+      @rule.update_attribute(:filter_field, filter)
+      Rule.apply_all @ticket
+
+      assert_includes @ticket.notified_users, dummy
+    end
+  end
+
 end


### PR DESCRIPTION
Pulling this request will fix issue [#227](https://github.com/ivaldi/brimir/issues/227) and extends the test suite for the rules model.

Below a .gif showing the behaviour by selecting the new "cc" rule and adding the selected label.

![output_ecn8mu](https://cloud.githubusercontent.com/assets/9994176/20591154/63b32b38-b227-11e6-836b-9d89bf11e4cc.gif)

New behaviour is that the _"to"_ filter will now filter on the actual _"to"_ address instead of the verified one, this functionality is added by adding a _"orig_to"_ column to the rules table, for _"cc"_ an additional column is added, _"orig_cc"_.