### PR TITLE
Fixed issue with captcha blocking ticket creation for not signed in users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with tickets missing a message_id. Constributed by @git-jls.
 - Disable captcha check for incoming email posts. Constributed by @git-jls.
 - Fixed signature and logic around recaptcha. Constributed by @git-jls.
+- Fixed issue for non signed in users not able to create tickets from the web gui when the captcha is disabled. Constributed by @git-jls.
 
 ### Security
 

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -165,8 +165,15 @@ class TicketsController < ApplicationController
       end
     else
       @ticket = Ticket.new(ticket_params)
-      if current_user.nil? && !verify_recaptcha
-        return render 'new'
+      # no signed in user
+      if current_user.nil?
+        # are the captcha's present?
+        if Ticket.recaptcha_keys_present?
+          # if they are present and not verified
+          if !verify_recaptcha
+            return render 'new'
+          end
+        end
       end
     end
 


### PR DESCRIPTION
As mentioned by @mickael-kerjean in issue [#310](https://github.com/ivaldi/brimir/issues/310), ticket creation from the web gui doesn't seem to work for non signed in users when the captcha is disabled.

This request should fix this.