### PR TITLE
Added Paperclip initialiser to support Supportworks Mail

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,0 +1,3 @@
+Paperclip.options[:content_type_mappings] = {
+  swm: %w(application/zip)
+}


### PR DESCRIPTION
Hello,

In our particular institution, we sometimes receive messages from Supportworks which contain an attachment with the 'swm' extension. These cause Brimir to fail as it doesn't recognise the extension. This patch adds a content type mapping to resolves this issue.

Thanks,
James