### PR TITLE
Define #attached_files based on #attachments. Fixes #347.

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -18,6 +18,9 @@ class Attachment < ApplicationRecord
   # polymorphic relation with tickets & replies
   belongs_to :attachable, polymorphic: true
 
+  scope :inline, -> { where.not(content_id: nil) }
+  scope :non_inline, -> { where(content_id: nil) }
+
   has_attached_file :file,
       path: Tenant.files_path,
       url: '/attachments/:id/:style',

--- a/app/models/concerns/email_message.rb
+++ b/app/models/concerns/email_message.rb
@@ -21,16 +21,18 @@ module EmailMessage
     has_many :attachments, as: :attachable, dependent: :destroy
     accepts_nested_attributes_for :attachments, allow_destroy: true
 
-    has_many :attached_files, -> { where(content_id: nil) }, as: :attachable, class_name: 'Attachment'
-
     has_attached_file :raw_message,
         path: Tenant.files_path
 
     do_not_validate_attachment_file_type :raw_message
   end
 
+  def attached_files
+    attachments.non_inline
+  end
+
   def inline_files
-    attachments.where.not(content_id: nil).map do |attachment|
+    attachments.inline.map do |attachment|
       [attachment.content_id, attachment.file.url(:original)]
     end.to_h
   end


### PR DESCRIPTION
To have `#attached_files` respect the `#attachments` of merged tickets,
redefine `#attached_files` based on `#attachments`.

```ruby
module EmailMessage
  def attached_files
    attachments.non_inline
  end
end

class Attachment
  scope :non_inline, -> { where(content_id: nil) }
end
```

Introducing scopes `Attachment.inline` and `Attachment.non_inline`.

Fixes #347.