### PR TITLE
Order Agents by email on 'New ticket' and 'Assign ticket' pages

### DIFF
--- a/app/views/tickets/_change_assignee_form.html.erb
+++ b/app/views/tickets/_change_assignee_form.html.erb
@@ -3,7 +3,7 @@
 
   <%= form_for ticket, remote: true, method: :patch do |f| %>
     <p>
-      <%= f.select :assignee_id, options_from_collection_for_select(@agents, 'id', 'email', ticket.assignee_id), { include_blank: t(:unassigned) }, { class: 'select2' } %>
+      <%= f.select :assignee_id, options_from_collection_for_select(@agents.ordered, 'id', 'email', ticket.assignee_id), { include_blank: t(:unassigned) }, { class: 'select2' } %>
     </p>
     <%= f.submit t(:assign), class: 'small success no-m button' %>
   <% end %>

--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -30,7 +30,7 @@
     <p>
       <%
         options = [ ['unassigned', nil] ]
-        User.agents.map.each {|u| options << [u.email, u.id]}
+        User.agents.ordered.map.each {|u| options << [u.email, u.id]}
       %>
     <%= f.select :assignee_id, options_for_select(options), {}, tabindex: tabindex %>
     </p>


### PR DESCRIPTION
There are a couple of places where the agents appear in select boxes in no particular order. This pull request orders them by email address.