### PR TITLE
Fixing issue with Google+ sign in link

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -43,7 +43,7 @@
       <p class="text-center">
         <% unless Rails.application.secrets[:google_client_id].blank? %>
         <%= t(:omniauth_sign_in_title) %>:
-          <%= link_to user_google_oauth2_omniauth_authorize_path(:google_oauth2) do %>
+          <%= link_to user_google_oauth2_omniauth_authorize_path do %>
             <i class="fa fa-google-plus-square"></i>
             <%= t(:omniauth_sign_in_google) %>
           <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -137,7 +137,7 @@
 
           <p><%= t(:omniauth_connect_text) %></p>
 
-          <%= link_to user_google_oauth2_omniauth_authorize_path(:google_oaut2) do %>
+          <%= link_to user_google_oauth2_omniauth_authorize_path do %>
             <i class="fa fa-google-plus-square"></i>
             <%= t(:omniauth_connect_google_text) %>
           <% end %>
@@ -153,4 +153,3 @@
     </div>
 
 <% end %>
-


### PR DESCRIPTION
The Google+ sign in link was updated as part of the Rails 5 upgrade, but the link format isn't correct now - it appends "google_oauth2" to the link and causes it to fail.

This commit fixes the issue.