### PR TITLE
send reply button now changes to 'attach note'

### DIFF
--- a/app/views/replies/_form.html.erb
+++ b/app/views/replies/_form.html.erb
@@ -87,10 +87,9 @@
       <p>
         <%= r.button t(:save_as_draft), name: 'reply[draft]', value: true, class: 'button regular radius primary' %>
 
-        <%= r.button t(:send_reply), name: 'reply[draft]', value: false, type: :submit, class: 'button regular radius secondary' %>
+        <%= r.button @reply.internal? ? t(:attach_note) : t(:send_reply), name: 'reply[draft]', value: false, type: :submit, class: 'reply-submit button regular radius secondary' %>
       </p>
 
     </div>
   </div>
 <% end %>
-

--- a/app/views/replies/new.js.erb
+++ b/app/views/replies/new.js.erb
@@ -8,9 +8,12 @@
 <% if @reply.internal? %>
   jQuery('iframe').contents().find('#tinymce').css('background-color', '#fff6d9');
   jQuery('#reply_content').css('background-color', '').css('background-color', '#fff6d9');
+  jQuery('.reply-submit').text('<%= I18n.t(:attach_note) %>')
 <% else %>
   jQuery('iframe').contents().find('#tinymce').css('background-color', '');
   jQuery('#reply_content').css('background-color', '');
+  jQuery('.reply-submit').text('<%= I18n.t(:send_reply) %>')
+
 <% end %>
 
 jQuery('[data-notified-users]').html('<%= j result %>');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,7 @@ en:
   attach_files: Attach file(s)
   attach_file: Attach file
   send_reply: Send reply
+  attach_note: Attach note
   on_date_author_wrote: 'On %{date}, %{author} wrote:'
   notification_will_be_sent_to: Your notification will be sent to
   save_as_draft: Save as draft


### PR DESCRIPTION
We've started using Brimir at https://www.epigenesys.org.uk and have found it great, however we've been double (or triple) checking when we are submitting an internal note that it is not sending a reply. This is a small change to help alleviate that.