### PR TITLE
Replace onfocus/onblur with visibility check

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require jquery-visibility/jquery-visibility
 //= require react
 //= require react_ujs
 //= require components

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require jquery-visibility/jquery-visibility
 //= require react
 //= require react_ujs
 //= require components

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -156,9 +156,11 @@
 </section>
 
 <script>
-  window.onblur = function() {
-    window.onfocus = function() {
-      location.reload(true);
-    };
-  };
+  document.addEventListener("DOMContentLoaded", function(event) {
+    $(document).on('hide', function() {
+      $(document).on('show', function() {
+        location.reload(true);
+      });
+    });
+  });
 </script>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -155,6 +155,7 @@
   <% end %>
 </section>
 
+<%= javascript_include_tag 'jquery-visibility' %>
 <script>
   document.addEventListener("DOMContentLoaded", function(event) {
     $(document).on('hide', function() {

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( application-print.css vendor/modernizr.js application-rtl.css )
+Rails.application.config.assets.precompile += %w( application-print.css vendor/modernizr.js application-rtl.css jquery-visibility/jquery-visibility.js )


### PR DESCRIPTION
As per #359, this replaces the current onfocus/onblur block in the main page with a check based on the Page Visibility API. 

The page will only refresh now if the page is hidden and then shown - it should stop the onblur check being intercepted when moving to other pages.