### PR TITLE
Replace onfocus/onblur with visibility check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'compass-rails', '~> 3.0.0'
 gem 'foundation-rails', '~> 5.5.0'
 
 gem 'jquery-rails', "~> 4.2"
+gem 'jquery-visibility-rails'
 
 # foundation form errors
 gem 'foundation_rails_helper', "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-visibility-rails (1.0.8)
     json (2.0.2)
     jwt (1.5.6)
     launchy (2.4.3)
@@ -296,6 +297,7 @@ DEPENDENCIES
   http_accept_language (~> 2.1)
   jbuilder (~> 2.6)
   jquery-rails (~> 4.2)
+  jquery-visibility-rails
   letter_opener (~> 1.4)
   mail
   mysql2 (~> 0.4)
@@ -319,4 +321,4 @@ DEPENDENCIES
   will_paginate (~> 3.1)
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require trix
 //= require tickets
 //= require fancybox
+//= require jquery-visibility
 
 (function() {
 

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -156,9 +156,11 @@
 </section>
 
 <script>
-  window.onblur = function() {
-    window.onfocus = function() {
-      location.reload(true);
-    };
-  };
+  document.addEventListener("DOMContentLoaded", function(event) {
+    $(document).on('hide', function() {
+      $(document).on('show', function() {
+        location.reload(true);
+      });
+    });
+  });
 </script>


### PR DESCRIPTION
As per #359, this replaces the current onfocus/onblur block in the main page with a check based on the Page Visibility API.

The page will only refresh now if the page is hidden and then shown - it should stop the onblur check being intercepted when moving to other pages.