### PR TITLE
feature: ui to rename ticket

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -115,6 +115,13 @@ class TicketsController < ApplicationController
 
         end
 
+        # change ticket subject
+        if @ticket.previous_changes.include? :subject
+          old_subject = @ticket.previous_changes[:subject].first
+          new_subject = @ticket.previous_changes[:subject].last
+          StatusReply.create_from_subject_change(@ticket, old_subject, new_subject, current_user)
+        end
+
         # status replies
         if @tenant.notify_client_when_ticket_is_assigned_or_closed
           if !@ticket.assignee.nil?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,7 +42,7 @@ class Ability
   def customer(user)
     # customers can view replies where they were notified of
     can :read, Reply do |reply|
-      reply.notified_user_ids.include? user.id || reply.user_id == user.id
+      reply.notified_user_ids.include? user.id || reply.user_id == user.id || reply.kind_of?(StatusReply)
     end
     # customers can view their own replies
     can :read, Reply, user_id: user.id

--- a/app/models/status_reply.rb
+++ b/app/models/status_reply.rb
@@ -12,6 +12,14 @@ class StatusReply < Reply
     create_from_status_message message, ticket, current_user
   end
 
+  def self.create_from_subject_change(ticket, old_subject, new_subject, current_user)
+    message = I18n.t(:str1_has_renamed_ticket_from_str2_to_str3, str1: current_user.name, str2: old_subject, str3: new_subject)
+    reply = create_from_status_message message, ticket, current_user
+    reply.notified_users = []
+    reply.save
+    return reply
+  end
+
   def self.create_from_status_message(message, ticket, current_user)
     reply = self.create content: message, ticket_id: ticket.id, user_id: current_user.id
     reply.reply_to = ticket

--- a/app/views/tickets/_change_subject_form.html.erb
+++ b/app/views/tickets/_change_subject_form.html.erb
@@ -1,0 +1,13 @@
+<div id="change-subject" class="reveal-modal small" data-reveal>
+  <h3><%= t(:change_subject) %></h3>
+
+  <%= form_for ticket, remote: true, method: :patch do |f| %>
+    <p>
+      <%= f.text_field :subject %>
+    </p>
+    <%= f.submit t(:change_subject), class: 'small success no-m button' %>
+  <% end %>
+
+  <a class="close-reveal-modal">&#215;</a>
+</div>
+

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -17,6 +17,13 @@
         <% end %>
         <h3 class="no-m text-default">
           <%= !@ticket.subject.blank? ? @ticket.subject : "<em>(#{t(:no_subject)})</em>".html_safe %>
+          <% if can? :update, @ticket %>
+            <small>
+              <a href="#" data-reveal-id="change-subject">
+                <span class="fa fa-fw fa-edit text-default"></span>
+              </a>
+            </small>
+          <% end %>
         </h3>
         <h5 class="text-default mb no-mt">
           <%= t(:ticket_by_at, email: link_to(@ticket.user.email, user_tickets_path(user_id: @ticket.user.id)), at: l(@ticket.created_at.in_time_zone(current_user.time_zone), format: :long)).html_safe %>
@@ -167,3 +174,4 @@
 <% end %>
 
 <%= render 'change_assignee_form', { ticket: @ticket } %>
+<%= render 'change_subject_form', { ticket: @ticket } %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -95,6 +95,10 @@ de:
   change_assignee: Ticket zuweisen
   assign: Ticket zuweisen
 
+# tickets/_change_subject_form
+  change_subject: Ticket umbenennen
+  str1_has_renamed_ticket_from_str2_to_str3: "%{str1} hat das Ticket von '%{str2}' in '%{str3}' umbenannt."
+
 # tickets/merge
   ticket_has_been_merged_to: "Dieses Ticket wurde mit Ticket #%{ticket_id} zusammengeführt."
   merge: Zusammenführen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,7 @@ en:
   assign: Assign
 
 # tickets/_change_subject_form
-  change_subject: Rename subject
+  change_subject: Rename ticket
   str1_has_renamed_ticket_from_str2_to_str3: "%{str1} has renamed the ticket from '%{str2}' to '%{str3}'."
 
 # tickets/locks/create

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,10 @@ en:
   change_assignee: Assign ticket
   assign: Assign
 
+# tickets/_change_subject_form
+  change_subject: Rename subject
+  str1_has_renamed_ticket_from_str2_to_str3: "%{str1} has renamed the ticket from '%{str2}' to '%{str3}'."
+
 # tickets/locks/create
   ticket_locked_by_somebody_else: Ticket is currently already being handled by somebody else
 


### PR DESCRIPTION
Sometimes, clients need a little help naming their tickets. This pull request adds a small button to rename the ticket. Renaming the ticket will create a status reply in the ticket history, but won't send a notification.

<img width="788" alt="bildschirmfoto 2017-06-12 um 17 58 29" src="https://user-images.githubusercontent.com/1679688/27043341-1ac29fc4-4f9a-11e7-96bc-5e6ef6a51a93.png">

<img width="779" alt="bildschirmfoto 2017-06-12 um 17 58 56" src="https://user-images.githubusercontent.com/1679688/27043343-1d89127e-4f9a-11e7-939a-3ba3314f3854.png">

<img width="785" alt="bildschirmfoto 2017-06-12 um 17 59 09" src="https://user-images.githubusercontent.com/1679688/27043347-2259c6ae-4f9a-11e7-978c-fd4d0bf6e4bd.png">

We have this in production since today. I'm going to report here in a couple of days if we encounter any issues.