### PR TITLE
feature: split off tickets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require select2
 //= require trix
 //= require tickets
+//= require replies
 //= require fancybox
 //= require jquery-visibility
 

--- a/app/assets/javascripts/replies.js
+++ b/app/assets/javascripts/replies.js
@@ -22,7 +22,7 @@ jQuery(function() {
         }
       });
 
-      event.preventDefault();
+      return false;
     }
   });
 });

--- a/app/assets/javascripts/replies.js
+++ b/app/assets/javascripts/replies.js
@@ -1,17 +1,17 @@
 jQuery(function() {
 
-  var current_selection = "";
+  var current_selection = '';
 
   jQuery(document).on('mouseup', 'body', function() {
     current_selection = window.getSelection().toString();
   })
 
   jQuery('.split-off-ticket').bind('click', function(event) {
-    if (current_selection != "") {
-      var url = $(this).attr('href') + ".json";
+    if (current_selection != '') {
+      var url = jQuery(this).attr('href') + '.json';
       var data = {
         selected_text: current_selection
-      }
+      };
 
       jQuery.ajax({
         url: url,
@@ -22,9 +22,7 @@ jQuery(function() {
         }
       });
 
-      event.stopPropagation();
       event.preventDefault();
-      return false;
     }
   });
 });

--- a/app/assets/javascripts/replies.js
+++ b/app/assets/javascripts/replies.js
@@ -1,0 +1,24 @@
+jQuery(function() {
+  //jQuery(document).on('click', '.split-off-ticket', function(event) {
+  jQuery('.split-off-ticket').bind('click', function(event) {
+    if (window.getSelection().toString() != "") {
+      var url = $(this).attr('href') + ".json";
+      var data = {
+        selected_text: window.getSelection().toString()
+      }
+
+      jQuery.ajax({
+        url: url,
+        type: 'post',
+        data: data,
+        success: function(result) {
+          window.location = result.ticket_path;
+        }
+      });
+
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+  });
+});

--- a/app/assets/javascripts/replies.js
+++ b/app/assets/javascripts/replies.js
@@ -1,10 +1,16 @@
 jQuery(function() {
-  //jQuery(document).on('click', '.split-off-ticket', function(event) {
+
+  var current_selection = "";
+
+  jQuery(document).on('mouseup', 'body', function() {
+    current_selection = window.getSelection().toString();
+  })
+
   jQuery('.split-off-ticket').bind('click', function(event) {
-    if (window.getSelection().toString() != "") {
+    if (current_selection != "") {
       var url = $(this).attr('href') + ".json";
       var data = {
-        selected_text: window.getSelection().toString()
+        selected_text: current_selection
       }
 
       jQuery.ajax({

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -126,6 +126,9 @@ ul.accordion{
 	list-style-type: none;
 	margin-left: 0;
 }
+.split-off-ticket{
+  font-size: 90%;
+}
 
 .output{
 	line-height: 1.45;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -130,6 +130,10 @@ ul.accordion{
   font-size: 90%;
 }
 
+a.pull-right{
+  margin-left: 15px;
+}
+
 .output{
 	line-height: 1.45;
 }

--- a/app/controllers/tickets/split_off_controller.rb
+++ b/app/controllers/tickets/split_off_controller.rb
@@ -11,7 +11,7 @@ class Tickets::SplitOffController < ApplicationController
       # then a new ticket is created with just that text.
       # This is useful if the client has presented several issues
       # in one ticket.
-      ticket.content = params[:selected_text] if params[:selected_text]
+      ticket.content = params[:selected_text]
     else
       # If the agent has not selected text, the reply is just converted
       # into a ticket. The reply can be destroyed as the complete reply

--- a/app/controllers/tickets/split_off_controller.rb
+++ b/app/controllers/tickets/split_off_controller.rb
@@ -5,10 +5,26 @@ class Tickets::SplitOffController < ApplicationController
     authorize! :split_off, reply
 
     ticket = reply.to_ticket
-    ticket.save
-    reply.destroy
 
-    redirect_to ticket
+    if params[:selected_text]
+      # If the agent has selected text when splitting off the ticket
+      # then a new ticket is created with just that text.
+      # This is useful if the client has presented several issues
+      # in one ticket.
+      ticket.content = params[:selected_text] if params[:selected_text]
+    else
+      # If the agent has not selected text, the reply is just converted
+      # into a ticket. The reply can be destroyed as the complete reply
+      # has been extracted into a ticket.
+      reply.destroy
+    end
+
+    ticket.save
+
+    respond_to do |format|
+      format.html { redirect_to ticket }
+      format.json { render json: { ticket_path: ticket_path(ticket) } }
+    end
   end
 
 end

--- a/app/controllers/tickets/split_off_controller.rb
+++ b/app/controllers/tickets/split_off_controller.rb
@@ -1,0 +1,14 @@
+class Tickets::SplitOffController < ApplicationController
+
+  def create
+    reply = Reply.find(params[:reply_id])
+    authorize! :split_off, reply
+
+    ticket = reply.to_ticket
+    ticket.save
+    reply.destroy
+
+    redirect_to ticket
+  end
+
+end

--- a/app/controllers/tickets/split_off_controller.rb
+++ b/app/controllers/tickets/split_off_controller.rb
@@ -12,6 +12,7 @@ class Tickets::SplitOffController < ApplicationController
       # This is useful if the client has presented several issues
       # in one ticket.
       ticket.content = params[:selected_text]
+      ticket.subject = ticket.content.first(100)
     else
       # If the agent has not selected text, the reply is just converted
       # into a ticket. The reply can be destroyed as the complete reply

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -69,6 +69,11 @@ class Ability
     # limited agents can view their own tickets, replies and attachments
     can [:create, :read], Reply, ticket: { user_id: user.id }
 
+    # agents can split off replies as tickets
+    can :split_off, Reply do |reply|
+      can?(:update, reply.ticket)
+    end
+
     # limited agents can edit their own account
     can :update, User, id: user.id
 
@@ -93,6 +98,9 @@ class Ability
 
     # can view all replies
     can :read, Reply
+
+    # agents can split off replies as tickets
+    can :split_off, Reply
 
     # agents can edit all users
     can [:read, :create, :update], User

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -66,4 +66,27 @@ class Reply < ApplicationRecord
   def first?
     reply_to_type == 'Ticket'
   end
+
+  def to_ticket
+    Ticket.new(
+      content: self.content,
+      subject: self.ticket.subject,
+      text_content: self.text_content,
+      created_at: self.created_at,
+      updated_at: self.updated_at,
+      user_id: self.user_id,
+      message_id: self.message_id,
+      content_type: self.content_type,
+      raw_message_file_name: self.raw_message_file_name,
+      raw_message_content_type: self.raw_message_content_type,
+      raw_message_file_size: self.raw_message_file_size,
+      raw_message_updated_at: self.raw_message_updated_at,
+      notified_user_ids: self.notified_user_ids,
+      attachments: self.attachments.collect { |attachment|
+        new_attachment = attachment.dup
+        new_attachment.file = attachment.file
+        new_attachment
+      }
+    )
+  end
 end

--- a/app/views/replies/_reply.html.erb
+++ b/app/views/replies/_reply.html.erb
@@ -43,6 +43,14 @@
         <% if reply.raw_message_file_size.to_i > 0 %>
           <a class="pull-right text-default" href="<%= reply_path(reply, format: :eml) %>"><%= fa_icon 'save' %></a>
         <% end %>
+
+        <% if can?(:split_off, reply) && !reply.kind_of?(StatusReply) %>
+          <%= link_to reply_split_off_path(reply_id: reply.id), method: 'post', class: 'pull-right text-default split-off-ticket' do %>
+            <i class="fa fa-code-fork"></i>
+            <%= t :split_off_ticket %>
+          <% end %>
+        <% end %>
+
         <% if reply.content_type == 'html' %>
           <% if reply.is_a? SystemReply %>
             <%= render('/shared/content_for_system_reply', reply: reply) %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -116,6 +116,10 @@ de:
   save_as_draft: Als Entwurf speichern
   internal_note: Interne Notiz
 
+# replies/_reply
+  reply_by: Antwort von
+  split_off_ticket: Ticket abspalten
+
 # ticket_mailer/notify_assigned.text.erb
   ticket_assigned: Ihnen wurde ein Ticket zugewiesen
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
 
 # replies/_reply
   reply_by: Reply by
+  split_off_ticket: Split off ticket
 
 # ticket_mailer/notify_assigned.text.erb
   ticket_assigned: Ticket assigned to you

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Brimir::Application.routes.draw do
   resources :labels, only: [:destroy, :update, :index, :edit]
 
   resources :replies, only: [:create, :new, :update, :show] do
-    post :split_off, to: 'tickets/split_off#create'
+    resource  :split_off, controller: 'tickets/split_off', only: [:create]
   end
 
   get '/attachments/:id/:format' => 'attachments#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,9 @@ Brimir::Application.routes.draw do
 
   resources :labels, only: [:destroy, :update, :index, :edit]
 
-  resources :replies, only: [:create, :new, :update, :show]
+  resources :replies, only: [:create, :new, :update, :show] do
+    post :split_off, to: 'tickets/split_off#create'
+  end
 
   get '/attachments/:id/:format' => 'attachments#show'
   resources :attachments, only: [:index, :new]


### PR DESCRIPTION
Our clients often reply to an existing ticket, but really want to discuss a separate issue. Therefore, this pull request provides a ui to split off tickets for two common use cases:

### Case 1: Client replies to an existing ticket after a while to raise another issue

In this use case, the client's issue has been resolved and the ticket has been closed. But after a while, the client replies to the ticket and reports a completely separate problem.

<img width="781" alt="bildschirmfoto 2017-06-13 um 00 25 00" src="https://user-images.githubusercontent.com/1679688/27058880-0cd7ffaa-4fd4-11e7-8bad-2117044a107e.png">

Click on "Split off ticket" in order to copy the reply into a new ticket and destroy the reply to the old ticket.

<img width="774" alt="bildschirmfoto 2017-06-13 um 00 25 32" src="https://user-images.githubusercontent.com/1679688/27058931-3f98b6fa-4fd4-11e7-8bb7-21cec85be63e.png">

After that, consider [renaming](https://github.com/ivaldi/brimir/pull/372) the new ticket.

### Case 2: Client replies, but raises another issue in the same reply

In this use case, the client's issue might or might not be resolved, yet. But in a reply, the client comes up with another issue, which is unrelated.

<img width="774" alt="bildschirmfoto 2017-06-13 um 00 27 58" src="https://user-images.githubusercontent.com/1679688/27058987-88f3ec70-4fd4-11e7-9533-266ff8c1b39e.png">

Select the part of the reply, which is unrelated to the current ticket and really should be a new ticket. After selecting the new issue, click "Split off ticket". This copies the selected text into a new ticket. The reply to the old ticket is not destroyed, because it contains information relevant to the old ticket.

<img width="779" alt="bildschirmfoto 2017-06-13 um 00 44 48" src="https://user-images.githubusercontent.com/1679688/27059023-ab5bcdf0-4fd4-11e7-939f-0f7fd0ae9fef.png">

After that, consider [renaming](https://github.com/ivaldi/brimir/pull/372) the new ticket.