### PR TITLE
feature: import eml files as new tickets

### DIFF
--- a/app/controllers/email_imports_controller.rb
+++ b/app/controllers/email_imports_controller.rb
@@ -1,0 +1,23 @@
+class EmailImportsController < ApplicationController
+
+  def new
+    authorize! :create, :email_imports
+  end
+
+  def create
+    authorize! :create, :email_imports
+
+    params[:files].each do |uploaded_file|
+      message = uploaded_file.tempfile.read
+      ticket = TicketMailer.receive(message)
+      NotificationMailer.incoming_message(ticket, message)
+    end
+
+    if params[:files].count == 1
+      redirect_to ticket_path(Ticket.last)
+    else
+      redirect_to tickets_path
+    end
+  end
+
+end

--- a/app/mailers/ticket_mailer.rb
+++ b/app/mailers/ticket_mailer.rb
@@ -125,7 +125,8 @@ class TicketMailer < ActionMailer::Base
         content_type: content_type,
         to_email_address: to_email_address,
         raw_message: StringIO.new(email.to_s),
-        unread_users: User.where(agent: true)
+        unread_users: User.where(agent: true),
+        created_at: (email.date || Time.zone.now)
       })
 
       incoming = ticket

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -122,6 +122,8 @@ class Ability
     can :manage, Label
     can :manage, EmailTemplate
 
+    can :create, :email_imports
+
     can :update, Tenant, id: Tenant.current_tenant.id
   end
 end

--- a/app/views/email_imports/_form.html.erb
+++ b/app/views/email_imports/_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_for :email_import, url: email_imports_path, html: {multipart: true} do |f| %>
+  <h3><%= t(:import_emails) %></h3>
+  <p><%= t(:upload_eml_files_to_import_them_as_new_tickets) %></p>
+
+  <div class="panel mb ptl pbl mbxl">
+    <h5><%= fa_icon 'paperclip fw' %><%= t(:upload_files) %></h5>
+
+    <%= file_field_tag :files, label: false, multiple: true, accept: '.eml', name: 'files[]' %>
+  </div>
+
+  <p><%= f.submit t(:perform_email_import), class: 'button regular radius' %></p>
+<% end %>

--- a/app/views/email_imports/new.html.erb
+++ b/app/views/email_imports/new.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="medium-9 columns" style="background: #fff">
+
+    <%= render 'form' %>
+
+  </div>
+</div>

--- a/app/views/replies/_reply.html.erb
+++ b/app/views/replies/_reply.html.erb
@@ -8,9 +8,9 @@
           </div>
           <div class="medium-11 columns pll pts prl">
             <span><%= t(:reply_by) %> <strong><%= reply.ticket.reply_from_address %></strong></span>
-            <span class="right" title="<%= l reply.updated_at.in_time_zone(current_user.time_zone), format: :long %>">
+            <span class="right" title="<%= l reply.created_at.in_time_zone(current_user.time_zone), format: :long %>">
               <i class="fa fa-clock-o"></i>
-              <%= time_ago_in_words(reply.updated_at.in_time_zone(current_user.time_zone)) %>
+              <%= time_ago_in_words(reply.created_at.in_time_zone(current_user.time_zone)) %>
               <%= t(:ago) %>
             </span>
           </div>
@@ -24,12 +24,12 @@
           </div>
           <div class="medium-11 columns pll pts prl">
             <span><%= t(:reply_by) %> <strong><%= reply.user.email %></strong></span>
-            <span class="right" title="<%= l reply.updated_at.in_time_zone(current_user.time_zone), format: :long %>">
+            <span class="right" title="<%= l reply.created_at.in_time_zone(current_user.time_zone), format: :long %>">
             <% if reply.attachments.count > 0 %>
               <i class="fa fa-paperclip"></i>
             <% end %>
               <i class="fa fa-clock-o"></i>
-              <%= time_ago_in_words(reply.updated_at.in_time_zone(current_user.time_zone)) %>
+              <%= time_ago_in_words(reply.created_at.in_time_zone(current_user.time_zone)) %>
               <%= t(:ago) %>
             </span>
           </div>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -1,4 +1,8 @@
 <div class="row">
+  <% if can? :create, :email_imports %>
+    <%= link_to t(:import_emails), new_email_import_path, class: 'button pull-right'%>
+  <% end %>
+
   <div class="medium-9 columns" style="background: #fff <%# for unauthenticated form %>">
 
     <%= render 'form' %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -101,6 +101,11 @@ de:
   merge_explanation: "Ausgewählte Tickets zusammenführen. Dies kopiert die Antworten der ausgewählten Tickets in das älteste diser Tickets. Die übrigen ausgewählten Tickets werden geschlossen."
   tickets_have_been_merged: "Tickets wurden zusammengeführt."
 
+# email_imports/new
+  import_emails: E-Mails importieren
+  upload_eml_files_to_import_them_as_new_tickets: "E-Mail-Dateien (*.eml) hochladen, um die E-Mails als neue Tickets zu importieren."
+  upload_files: Dateien hochladen
+  perform_email_import: E-Mail-Import ausführen
 
 # replies/new
   add_reply: Antworten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,12 @@ en:
   merge_explanation: "Merge the selected tickets. This copies all replies to the oldest of the selected tickets and closes the other selected tickets."
   tickets_have_been_merged: "Tickets have been merged."
 
+# email_imports/new
+  import_emails: Import emails
+  upload_eml_files_to_import_them_as_new_tickets: "Upload eml files here in order to import them as new tickets."
+  upload_files: Upload files
+  perform_email_import: Perform email import
+
 # replies/new
   add_reply: Add reply
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Brimir::Application.routes.draw do
   resources :attachments, only: [:index, :new]
 
   resources :email_addresses
+  resources :email_imports, only: [:new, :create]
 
   resource :settings, only: [:edit, :update]
 


### PR DESCRIPTION
Sometimes, people who know the support staff in person, won't write emails to the support email address but to the agents' personal email addresses. We've tried really hard, but we can't get these clients to write to the support email address.

This workaround allows to upload email files (*.eml) from the local mail client and to import them as new tickets.

As uploading multiple files is supported, I guess, this can also be used when migrating to brimir in the first place.

## How to

Click on "New ticket", then on "import emails".

![bildschirmfoto 2017-06-13 um 09 43 31](https://user-images.githubusercontent.com/1679688/27079812-7f44bcee-5039-11e7-829b-017d3cf49f76.png)

![bildschirmfoto 2017-06-13 um 09 45 37](https://user-images.githubusercontent.com/1679688/27079816-8467ad4e-5039-11e7-8cdb-e4b44f53438b.png)

![bildschirmfoto 2017-06-13 um 09 46 27](https://user-images.githubusercontent.com/1679688/27079828-8b5b91a6-5039-11e7-9f99-d77d427301e2.png)

![bildschirmfoto 2017-06-13 um 09 45 58](https://user-images.githubusercontent.com/1679688/27079839-931dd3fe-5039-11e7-96d3-c4bcc11d5211.png)

After importing several emails from the same thread, it might be useful to [merge them](https://github.com/ivaldi/brimir/pull/242).

## Caveats

- In `TicketMailer#receive`, I'm setting the `created_at` column to the email date (https://github.com/ivaldi/brimir/compare/master...fiedl:sf/email-import?expand=1#diff-88f33be098889e6fd2fc29f54e354ab9). If this is undesired, we might need to introduce a `sent_at` column; but I guess the present solution will do.
- In `tickets#show`, I needed to change the field, which determines the reply dates, from `updated_at` to `created_at` (https://github.com/ivaldi/brimir/commit/905ee91683a77f1848d6880290b7a9beaf64a36d). Otherwise, uploading two emails from yesterday and merging them would show the wrong reply date. I'm not sure why it has been `Reply#uploaded_at` in the first place, but it might be something to consider.