### PR TITLE
if there is no ticktes selected for merge, then redirect back.

### DIFF
--- a/app/controllers/tickets/selected_controller.rb
+++ b/app/controllers/tickets/selected_controller.rb
@@ -51,9 +51,10 @@ module Tickets
 
       unless @tickets.count == 0
         merged_ticket = Ticket.merge @tickets, current_user: current_user
+        redirect_to merged_ticket, notice: t(:tickets_have_been_merged)
+      else
+        redirect_to :back, notice: t(:tickets_status_modified)
       end
-      redirect_to merged_ticket, notice: t(:tickets_have_been_merged)
     end
   end
 end
-


### PR DESCRIPTION
Fix issue #384 