### PR TITLE
Add validations when creating ticket from a web form

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -224,7 +224,7 @@ class TicketsController < ApplicationController
 
   protected
   def can_create_a_ticket(using_hook)
-    if @ticket.nil? || !@ticket.valid?
+    if @ticket.nil? || !@ticket.valid? || (!using_hook && !@ticket.valid?(:web_form))
       flash.now[:alert] = I18n::translate(:form_validation_error)
       false
     # relax policy for requests coming from emails

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -20,6 +20,7 @@ class Ticket < ApplicationRecord
   include TicketMerge
 
   validates_presence_of :user_id
+  validates_presence_of :content, :subject, on: :web_form
 
   belongs_to :user
   belongs_to :assignee, class_name: 'User'


### PR DESCRIPTION
~I added an `attr_accessor` to Ticket. When this attribute is true, it will skip the validations for `content` and `subject`.~

Hope this helps! I am happy to make infinite changes, so let me know if I missed anything/could do something better 😄  

closes #386 