### PR TITLE
redirect to ticket list after updating ticket

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -80,7 +80,7 @@ class RepliesController < ApplicationController
           @reply.notification_mails.each(&:deliver_now)
         end
 
-        redirect_to @reply.ticket, notice: I18n::translate(:reply_added)
+        redirect_to tickets_url, notice: I18n::translate(:reply_added)
       end
     rescue => e
       Rails.logger.error 'Exception occured on Reply transaction!'

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -19,6 +19,7 @@ require 'test_helper'
 class NotificationMailerTest < ActionMailer::TestCase
 
   test 'should notify assignee of new ticket' do
+    Tenant.current_domain = tenants(:main).domain
     ticket = tickets(:problem)
 
     assert_difference 'ActionMailer::Base.deliveries.size' do
@@ -32,6 +33,7 @@ class NotificationMailerTest < ActionMailer::TestCase
   end
 
   test 'should notify user of new reply' do
+    Tenant.current_domain = tenants(:main).domain
     reply = replies(:solution)
 
     assert_difference 'ActionMailer::Base.deliveries.size' do


### PR DESCRIPTION
A common complaint I'm getting here is that our agents would rather be sent back to the ticket list after replying, rather than going back to the ticket they just updated.

This PR changes the redirect location to send the agent back to the ticket list after they reply to a ticket.