### PR TITLE
set missing instance vars - resolves #412

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -19,6 +19,8 @@ class RepliesController < ApplicationController
   load_and_authorize_resource
 
   def new
+    @users = User.actives
+    @users = @users.agents if @reply.internal?
     @reply.assign_attributes(reply_params)
   end
 


### PR DESCRIPTION
This resolves #412 

Earlier changes to some partials led to a 500 error on replies#new due to missing instance vars.  This PR gets those defined and resolves the 500 error.