### PR TITLE
Rename "billet" to "ticket" in fr-FR locale

### DIFF
--- a/config/locales/fr-FR.yml
+++ b/config/locales/fr-FR.yml
@@ -1,10 +1,10 @@
 # author: https://github.com/social-org and https://github.com/sapk
 fr-FR:
-  language_name: Française
+  language_name: Français
 # layouts/application
-  new_ticket: Nouveau Billet
+  new_ticket: Nouveau ticket
   inbox: Boîte de réception
-  mine: Mes Billets
+  mine: Mes tickets
   closed_tickets: Fermé
   trashed: Corbeille
   users: Utilisateurs
@@ -13,7 +13,7 @@ fr-FR:
   sign_out: Se déconnecter
   delete: Supprimer
   close: Fermer
-  wait: En Attente
+  wait: En attente
   merge: Fusionner
 
   joyride:
@@ -49,16 +49,16 @@ fr-FR:
 
 # tickets/index
   count_tickets:
-    one: '%{count} billet'
-    other: '%{count} billets'
+    one: '%{count} ticket'
+    other: '%{count} tickets'
   count_tickets_containing:
-    one: '%{count} billet contenant'
-    other: '%{count} billets contenant'
+    one: '%{count} ticket contenant'
+    other: '%{count} tickets contenant'
   priority: Priorité
   replies: réponses
   no_subject: Aucun sujet
   unassigned: Non affecté
-  no_tickets_found: Aucun billet trouvé.
+  no_tickets_found: Aucun ticket trouvé.
   search: Recherche
   filter: Filtre
   minutes: minutes
@@ -97,7 +97,7 @@ fr-FR:
   change_status: Changer le statut
 
 # tickets/_change_assignee_form
-  change_assignee: Attribuer un billet
+  change_assignee: Attribuer un ticket
   assign: Attribuer
 
 # tickets/locks/create
@@ -116,20 +116,20 @@ fr-FR:
   save_as_draft: Enregistrer comme brouillon
 
 # replies/_reply
-  reply_by: Réponse de 
+  reply_by: Réponse de
 
 # ticket_mailer/notify_assigned.text.erb
-  ticket_assigned: Un billet de support vous a été attribué
+  ticket_assigned: Un ticket de support vous a été attribué
 
 # ticket_mailer/notify_priority_changed.text.erb
-  ticket_priority_changed: Priorité modifié pour le billet
+  ticket_priority_changed: Priorité modifié pour le ticket
 
 # ticket_mailer/notify_status_changed.text.erb
-  ticket_status_modified: Statut modifié pour le billet
-  tickets_status_modified: Statut modifié pour les billets
+  ticket_status_modified: Statut modifié pour le ticket
+  tickets_status_modified: Statut modifié pour les tickets
 
 # notification_mailer/new_ticket
-  view_new_ticket: Voir le nouveau billet
+  view_new_ticket: Voir le nouveau ticket
 # notification_mailer/new_reply
   new_reply: Nouvelle réponse
   view_new_reply: Voir la nouvelle réponse
@@ -157,11 +157,11 @@ fr-FR:
   account_settings: Paramètres du compte
   only_fill_in_passwords_when_modifying: Remplir ces deux champs seulement si vous souhaitez modifier votre mot de passe.
   user_is_an_agent: L'utilisateur est un agent
-  receive_new_ticket_notifications: Recevoir les notifications des nouveaux billets
+  receive_new_ticket_notifications: Recevoir les notifications des nouveaux tickets
   email_settings: Paramètres du courriel
   save: Enregister
   access_control: Contrôle d'accés
-  have_access_to_label: L'utilisateur a accés à tous les billets avec l'une de ces étiquettes.
+  have_access_to_label: L'utilisateur a accés à tous les tickets avec l'une de ces étiquettes.
 
 # settings/edit
   change_settings: Modifier les paramètres
@@ -182,16 +182,16 @@ fr-FR:
 
 # controllers/tickets
   ticket_added_public: Votre demande a été transmise au service compétent, qui ne manquera pas de vous apporter une réponse dès que possible
-  ticket_added: Billet ajouté
-  ticket_updated: Billet mise à jour
+  ticket_added: Ticket ajouté
+  ticket_updated: Ticket mise à jour
   ticket_error: Merci de bien remplir le formulaire correctement
   captcha_error: Merci de résoudre le captcha correctement
 
-  ticket_added: Billet ajouté
-  ticket_updated: Billet mise à jour
+  ticket_added: Ticket ajouté
+  ticket_updated: Ticket mise à jour
 
 # controllers/tickets/deleted
-  trash_emptied: Tous les billets ont été supprimés de la corbeille
+  trash_emptied: Tous les tickets ont été supprimés de la corbeille
 
 # controllers/replies
   reply_added: Réponse ajoutée
@@ -235,7 +235,7 @@ fr-FR:
   email_address_modified: Addresse email modifiée
   email_address_added: Addresse email ajoutée
   email_address_removed: Addresse email supprimée
-  
+
   activerecord:
     attributes:
       user:
@@ -264,7 +264,7 @@ fr-FR:
         assignee_id: Attribué
         created_at: Crée à
         to: Adresse email destinatiaire
-        
+
       reply:
         from: Adresse email source
 


### PR DESCRIPTION
I've just learned thanks to @thehunt33r that Québec has some pretty weird laws concerning anglicisms which may be why fr-CA translates ticket with "billet".

Right now, fr-FR is just a clone of fr-CA, but since the term "ticket" is way more common in this context, I've fixed the fr-FR locale accordingly. (An alternative term would be "dossier", however, it's more common for old-school businesses such as ex-monopole telco.)

Titles are not capitalized in fr-FR the way this is common in EN, fixed that as well.