### PR TITLE
Basic implementation of canned responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Ability to import .eml files for mails sent to wrong email address. Contributed by @fiedl.
 - Ability to rename tickets. Contributed by @fiedl.
+- Canned responses. Contributed by @svoop.
 
 ### Changed
 - Better error messages when an invalid input is given for non-signed in users. Contributed by @mickael-kerjean.

--- a/app/assets/javascripts/tickets.js
+++ b/app/assets/javascripts/tickets.js
@@ -69,6 +69,20 @@ jQuery(function() {
     }
   });
 
+  jQuery('#canned-response').on('change', function(){
+    var editor = jQuery(this).parents('form#new_reply').find('trix-editor')[0].editor;
+    var url = this.value;
+    if (url) {
+      jQuery.ajax({
+        url: url
+      }).done(function(response) {
+        editor.loadHTML(response.message);
+      });
+    } else {
+      editor.loadHTML('');
+    }
+  });
+
   if(jQuery('[data-lock-path]').length > 0) {
 
     function keepLock() {

--- a/app/controllers/api/v1/email_templates_controller.rb
+++ b/app/controllers/api/v1/email_templates_controller.rb
@@ -13,25 +13,11 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+class Api::V1::EmailTemplatesController < Api::V1::ApplicationController
 
-class Api::V1::ApplicationController < ActionController::Base
-  include MultiTenancy
+  load_and_authorize_resource :email_template
 
-  protect_from_forgery with: :null_session
-
-  before_action :authenticate_user_from_token!, unless: -> { current_user }
-  before_action :load_tenant
-
-  check_authorization
-
-  def authenticate_user_from_token!
-    user_token = params[:auth_token].presence
-    user = user_token && User.where(authentication_token: user_token.to_s).first
-
-    if user && Devise.secure_compare(user.authentication_token, params[:auth_token])
-      sign_in user, store: false
-    else
-      render nothing: true, status: :unauthorized
-    end
+  def show
+    render json: @email_template.to_json
   end
 end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -29,7 +29,8 @@ class TicketsController < ApplicationController
 
   def show
     @users = User.actives
-    
+    @canned_responses = EmailTemplate.canned_responses.order(:name)
+
     # first time seeing this ticket?
     @ticket.mark_read current_user if @ticket.is_unread? current_user
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -83,6 +83,8 @@ class Ability
       # at least one label_id overlap
       (reply.ticket.label_ids & user.label_ids).size > 0
     end
+
+    can :read, EmailTemplate
   end
 
   def agent(user)

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -1,9 +1,10 @@
 class EmailTemplate < ApplicationRecord
 
-  enum kind: [:user_welcome, :ticket_received]
+  enum kind: [:user_welcome, :ticket_received, :canned_response]
 
   scope :by_kind, -> (k) { where(kind: kinds[k]) }
   scope :active, -> { where.not(draft: true) }
+  scope :canned_responses, -> { where(kind: :canned_response) }
 
   validates_presence_of :kind
 
@@ -15,7 +16,7 @@ class EmailTemplate < ApplicationRecord
   end
 
   def is_active?
-    !draft?
+    kind == 'canned_response' || !draft?
   end
 
   def all_others_to_draft(kind)

--- a/app/views/email_templates/index.html.erb
+++ b/app/views/email_templates/index.html.erb
@@ -27,7 +27,7 @@
             <td><%= email_template.name %></td>
             <td><%= email_template.kind.humanize %></td>
             <td>
-              <% if email_template.is_active?  %>
+              <% if email_template.is_active? %>
                   <%= fa_icon 'check' %>
               <% else %>
                 <%= link_to t(:set_active), email_template_path(
@@ -54,4 +54,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/replies/_canned_responses.html.erb
+++ b/app/views/replies/_canned_responses.html.erb
@@ -1,0 +1,4 @@
+<div data-canned-responses>
+  <% options = options_for_select @canned_responses.map { |c| [c.name, api_v1_email_template_path(c)] } %>
+  <%= select_tag nil, options, id: 'canned-response', include_blank: true %>
+</div>

--- a/app/views/replies/_form.html.erb
+++ b/app/views/replies/_form.html.erb
@@ -37,6 +37,17 @@
         </div>
       </div>
 
+      <% if @canned_responses.any? %>
+        <div class="row collapse mbl">
+          <div class="medium-4 columns">
+            <label><%= t(:canned_response) %></label>
+          </div>
+          <div class="medium-8 columns">
+            <%= render 'replies/canned_responses' %>
+          </div>
+        </div>
+      <% end %>
+
       <%
         if @reply.content.blank? && @reply.errors.count == 0 # not on reply error view
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -122,6 +122,7 @@ de:
   attach_note: Notiz anhängen
   on_date_author_wrote: 'Am %{date} hat %{author} folgendes geschrieben:'
   notification_will_be_sent_to: 'Es wird eine Benachrichtung an folgende Adresse gesendet:'
+  canned_response: Vorbereitete Antwort
   save_as_draft: Als Entwurf speichern
   internal_note: Interne Notiz
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ en:
   attach_note: Attach note
   on_date_author_wrote: 'On %{date}, %{author} wrote:'
   notification_will_be_sent_to: Your notification will be sent to
+  canned_response: Canned response
   save_as_draft: Save as draft
   internal_note: Internal note
 
@@ -409,4 +410,4 @@ en:
         notify_client_when_ticket_is_created: Notify the client when his newly created ticket is received.
         notify_user_when_account_is_created: Notify user when account is created.
         stylesheet_url: Add the path to your own custom stylesheet.
-        ticket_creation_is_open_to_the_world: Tickets creation is open to everybody. 
+        ticket_creation_is_open_to_the_world: Tickets creation is open to everybody.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,6 @@
 # author: https://www.facebook.com/aunsinpagina & daniel.seijo_at_urbincasa.es
 # revisions: http://colina.net.ve e1th0r
-# 
+#
 es:
   language_name: Español
 # layouts/application
@@ -23,7 +23,7 @@ es:
   change_password: Cambiar contraseña
   new_password: Nueva contraseña
   new_password_confirmation: Confirmar nueva contraseña
-  
+
 # devise/mailer/reset_password_instructions
   hello: Hola
   someone_requested_link: Alguien ha solicitado un enlace para cambiar tu contraseña, puedes proceder haciendo click en el siguiente enlace.
@@ -89,7 +89,7 @@ es:
 # notification_mailer/new_reply
   new_reply: Nueva respuesta
   view_new_reply: Ver nueva respuesta
-  
+
 # attachments/_attachment
   download: Descargar
 
@@ -197,6 +197,7 @@ es:
   new_rule: Nueva regla
   no_notifications_sent: 'Ninguna notificación ha sido enviada'
   notification_will_be_sent_to: Tus notificaciones serán enviadas a
+  canned_response: Respuesta preparada
   personal_settings: Configuración personal
   rule_added: Regla añadida
   rule_modified: Regla modificada

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -85,6 +85,7 @@ fr-CA:
   send_reply: Envoyer réponse
   on_date_author_wrote: 'Le %{date}, %{author} a écrit:'
   notification_will_be_sent_to: Votre notification sera envoyé a
+  canned_response: Réponse préparée
 
 # ticket_mailer/notify_assigned.text.erb
   ticket_assigned: Un billet de support vous a été attribué

--- a/config/locales/fr-FR.yml
+++ b/config/locales/fr-FR.yml
@@ -113,10 +113,11 @@ fr-FR:
   send_reply: Envoyer réponse
   on_date_author_wrote: 'Le %{date}, %{author} a écrit:'
   notification_will_be_sent_to: Votre notification sera envoyé a
+  canned_response: Réponse préparée
   save_as_draft: Enregistrer comme brouillon
 
 # replies/_reply
-  reply_by: Réponse de 
+  reply_by: Réponse de
 
 # ticket_mailer/notify_assigned.text.erb
   ticket_assigned: Un billet de support vous a été attribué
@@ -235,7 +236,7 @@ fr-FR:
   email_address_modified: Addresse email modifiée
   email_address_added: Addresse email ajoutée
   email_address_removed: Addresse email supprimée
-  
+
   activerecord:
     attributes:
       user:
@@ -264,7 +265,7 @@ fr-FR:
         assignee_id: Attribué
         created_at: Crée à
         to: Adresse email destinatiaire
-        
+
       reply:
         from: Adresse email source
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Brimir::Application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      resources :email_templates, only: [ :show ]
       resources :tickets, only: [ :index, :show, :create ]
       resources :sessions, only: [ :create ]
       resources :users, param: :email, only: [ :create, :show ] do

--- a/test/controllers/api/v1/email_templates_controller_test.rb
+++ b/test/controllers/api/v1/email_templates_controller_test.rb
@@ -1,5 +1,5 @@
 # Brimir is a helpdesk system to handle email support requests.
-# Copyright (C) 2012-2016 Ivaldi https://ivaldi.nl/
+# Copyright (C) 2012-2015 Ivaldi https://ivaldi.nl/
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -14,24 +14,23 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-class Api::V1::ApplicationController < ActionController::Base
-  include MultiTenancy
+require 'test_helper'
 
-  protect_from_forgery with: :null_session
+class Api::V1::EmailTemplatesControllerTest < ActionController::TestCase
 
-  before_action :authenticate_user_from_token!, unless: -> { current_user }
-  before_action :load_tenant
-
-  check_authorization
-
-  def authenticate_user_from_token!
-    user_token = params[:auth_token].presence
-    user = user_token && User.where(authentication_token: user_token.to_s).first
-
-    if user && Devise.secure_compare(user.authentication_token, params[:auth_token])
-      sign_in user, store: false
-    else
-      render nothing: true, status: :unauthorized
-    end
+  setup do
+    @email_template = email_templates(:canned_response)
   end
+
+  test 'should show email template' do
+    sign_in users(:alice)
+
+    get :show, params: {
+      auth_token: users(:bob).authentication_token,
+      id: @email_template.id,
+      format: :json
+    }
+    assert_response :success
+  end
+
 end

--- a/test/fixtures/email_templates.yml
+++ b/test/fixtures/email_templates.yml
@@ -29,3 +29,11 @@ inactive_user_welcome:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
   draft: true
+
+canned_response:
+  name: Canned response
+  kind: <%= EmailTemplate.kinds[:canned_response] %>
+  message: 'Been there, done that.'
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  draft: false


### PR DESCRIPTION
"Canned responses" are prepared emails to prevent having to write the same responses to evergreen tickets all the time. This basic implementation simply adds a new `EmailTemplate` kind "canned-response" which can then be selected from the reply form.

---

First of all, you have to create at least one email template of kind "canned response":

<img width="612" alt="screen shot 2018-10-01 at 15 30 49" src="https://user-images.githubusercontent.com/7255/46291634-4b5a3b80-c58f-11e8-8b67-651f661d7de0.png">

To keep things simple, canned responses are not mutually exclusive but always active:

<img width="981" alt="screen shot 2018-10-01 at 15 31 17" src="https://user-images.githubusercontent.com/7255/46291685-6af16400-c58f-11e8-9593-10ba42910c3e.png">

Now, a new dropdown shows up on the reply form:

<img width="651" alt="screen shot 2018-10-01 at 15 31 30" src="https://user-images.githubusercontent.com/7255/46291720-7ba1da00-c58f-11e8-9294-20e5d2b38a08.png">

Choose the canned response of your choice and it prefills the text editor:

<img width="653" alt="screen shot 2018-10-01 at 15 31 44" src="https://user-images.githubusercontent.com/7255/46291748-8f4d4080-c58f-11e8-8f25-5a06b45f0410.png">
