### PR TITLE
Ignore .ruby-version and deployment-only files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 
+# Ignore Ruby version file
+/.ruby-version
+
 # Ignore bundler config
 /.bundle
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 /db/*.sqlite3
 
 # Ignore all logfiles and tempfiles.
-/log/*.log
+/log
 /tmp
 
 # No scaffold css
@@ -27,6 +27,10 @@ app/assets/stylesheets/scaffolds.css.scss
 # uploads
 public/system
 data
+
+# manual deploy with Git
+public/assets
+vendor/bundle
 
 # Capistrano deploy details
 config/deploy


### PR DESCRIPTION
A tiny PR excluding `.ruby-version` from Git. As an alternative, `.ruby-version` could also be checked in, but many projects prefer not to.