### PR TITLE
Rename canned response to canned reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Ability to import .eml files for mails sent to wrong email address. Contributed by @fiedl.
 - Ability to rename tickets. Contributed by @fiedl.
-- Canned responses. Contributed by @svoop.
+- Canned replies. Contributed by @svoop.
 - Support for incoming mail from Mailgun. Contributed by @svoop.<br>:warning: If you are already using the `post-mail` script, you must update the `aliases` file of your MTA according to the example mentioned in the README!
 
 ### Changed

--- a/app/assets/javascripts/tickets.js
+++ b/app/assets/javascripts/tickets.js
@@ -69,7 +69,7 @@ jQuery(function() {
     }
   });
 
-  jQuery('#canned-response').on('change', function(){
+  jQuery('#canned-reply').on('change', function(){
     var editor = jQuery(this).parents('form#new_reply').find('trix-editor')[0].editor;
     var url = this.value;
     if (url) {

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -32,7 +32,6 @@ class TicketsController < ApplicationController
 
   def show
     @users = User.actives
-    @canned_responses = EmailTemplate.canned_responses.order(:name)
 
     # first time seeing this ticket?
     @ticket.mark_read current_user if @ticket.is_unread? current_user

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -1,10 +1,10 @@
 class EmailTemplate < ApplicationRecord
 
-  enum kind: [:user_welcome, :ticket_received, :canned_response]
+  enum kind: [:user_welcome, :ticket_received, :canned_reply]
 
   scope :by_kind, -> (k) { where(kind: kinds[k]) }
   scope :active, -> { where.not(draft: true) }
-  scope :canned_responses, -> { where(kind: :canned_response) }
+  scope :canned_replies, -> { where(kind: :canned_reply) }
 
   validates_presence_of :kind
 
@@ -16,7 +16,7 @@ class EmailTemplate < ApplicationRecord
   end
 
   def is_active?
-    kind == 'canned_response' || !draft?
+    kind == 'canned_reply' || !draft?
   end
 
   def all_others_to_draft(kind)

--- a/app/views/replies/_canned_replies.html.erb
+++ b/app/views/replies/_canned_replies.html.erb
@@ -1,0 +1,4 @@
+<div data-canned-replies>
+  <% options = options_for_select @canned_replies.map { |c| [c.name, api_v1_email_template_path(c)] } %>
+  <%= select_tag nil, options, id: 'canned-reply', include_blank: true %>
+</div>

--- a/app/views/replies/_canned_responses.html.erb
+++ b/app/views/replies/_canned_responses.html.erb
@@ -1,4 +1,0 @@
-<div data-canned-responses>
-  <% options = options_for_select @canned_responses.map { |c| [c.name, api_v1_email_template_path(c)] } %>
-  <%= select_tag nil, options, id: 'canned-response', include_blank: true %>
-</div>

--- a/app/views/replies/_form.html.erb
+++ b/app/views/replies/_form.html.erb
@@ -37,13 +37,13 @@
         </div>
       </div>
 
-      <% if @canned_responses.any? %>
+      <% if (@canned_replies = EmailTemplate.canned_replies.order(:name)).any? %>
         <div class="row collapse mbl">
           <div class="medium-4 columns">
-            <label><%= t(:canned_response) %></label>
+            <label><%= t(:canned_reply) %></label>
           </div>
           <div class="medium-8 columns">
-            <%= render 'replies/canned_responses' %>
+            <%= render 'replies/canned_replies' %>
           </div>
         </div>
       <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -122,7 +122,7 @@ de:
   attach_note: Notiz anhängen
   on_date_author_wrote: 'Am %{date} hat %{author} folgendes geschrieben:'
   notification_will_be_sent_to: 'Es wird eine Benachrichtung an folgende Adresse gesendet:'
-  canned_response: Vorbereitete Antwort
+  canned_reply: Vorbereitete Antwort
   save_as_draft: Als Entwurf speichern
   internal_note: Interne Notiz
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,7 +130,7 @@ en:
   attach_note: Attach note
   on_date_author_wrote: 'On %{date}, %{author} wrote:'
   notification_will_be_sent_to: Your notification will be sent to
-  canned_response: Canned response
+  canned_reply: Canned reply
   save_as_draft: Save as draft
   internal_note: Internal note
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -197,7 +197,7 @@ es:
   new_rule: Nueva regla
   no_notifications_sent: 'Ninguna notificación ha sido enviada'
   notification_will_be_sent_to: Tus notificaciones serán enviadas a
-  canned_response: Respuesta preparada
+  canned_reply: Respuesta preparada
   personal_settings: Configuración personal
   rule_added: Regla añadida
   rule_modified: Regla modificada

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -85,7 +85,7 @@ fr-CA:
   send_reply: Envoyer réponse
   on_date_author_wrote: 'Le %{date}, %{author} a écrit:'
   notification_will_be_sent_to: Votre notification sera envoyé a
-  canned_response: Réponse préparée
+  canned_reply: Réponse préparée
 
 # ticket_mailer/notify_assigned.text.erb
   ticket_assigned: Un billet de support vous a été attribué

--- a/config/locales/fr-FR.yml
+++ b/config/locales/fr-FR.yml
@@ -113,7 +113,7 @@ fr-FR:
   send_reply: Envoyer réponse
   on_date_author_wrote: 'Le %{date}, %{author} a écrit:'
   notification_will_be_sent_to: Votre notification sera envoyé a
-  canned_response: Réponse préparée
+  canned_reply: Réponse préparée
   save_as_draft: Enregistrer comme brouillon
 
 # replies/_reply

--- a/test/controllers/api/v1/email_templates_controller_test.rb
+++ b/test/controllers/api/v1/email_templates_controller_test.rb
@@ -19,7 +19,7 @@ require 'test_helper'
 class Api::V1::EmailTemplatesControllerTest < ActionController::TestCase
 
   setup do
-    @email_template = email_templates(:canned_response)
+    @email_template = email_templates(:canned_reply)
   end
 
   test 'should show email template' do

--- a/test/fixtures/email_templates.yml
+++ b/test/fixtures/email_templates.yml
@@ -30,9 +30,9 @@ inactive_user_welcome:
   updated_at: <%= Time.now %>
   draft: true
 
-canned_response:
+canned_reply:
   name: Canned response
-  kind: <%= EmailTemplate.kinds[:canned_response] %>
+  kind: <%= EmailTemplate.kinds[:canned_reply] %>
   message: 'Been there, done that.'
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>


### PR DESCRIPTION
@frenkel Sorry for this followup PR: I've introduced a bug with #435 which has no effect on the application itself, but caused one test to go red. It has slipped my attention. Here's the fix for this and while I'm at it, I've renamed "canned response" to "canned reply" for consistency.