### PR TITLE
Optionally ask for name on new ticket forms

### DIFF
--- a/app/controllers/concerns/tickets_strong_params.rb
+++ b/app/controllers/concerns/tickets_strong_params.rb
@@ -21,6 +21,7 @@ module TicketsStrongParams
     if !current_user.nil? && current_user.agent?
       params.require(:ticket).permit(
         :from,
+        :name,
         :to_email_address_id,
         :content,
         :subject,
@@ -35,6 +36,7 @@ module TicketsStrongParams
     else
       params.require(:ticket).permit(
         :from,
+        :name,
         :content,
         :subject,
         :priority,

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -45,6 +45,7 @@ class SettingsController < ApplicationController
       :notify_user_when_account_is_created,
       :notify_client_when_ticket_is_created,
       :ticket_creation_is_open_to_the_world,
+      :ask_for_name,
       :stylesheet_url,
       :always_notify_me,
       :work_can_wait
@@ -57,7 +58,7 @@ class SettingsController < ApplicationController
           format: "%B"
     end
   end
-  
+
   def day_names
     @day_names = (1..7).map do |m|
       I18n.l DateTime.parse(Date::MONTHNAMES[m])

--- a/app/models/concerns/create_from_user.rb
+++ b/app/models/concerns/create_from_user.rb
@@ -18,10 +18,9 @@ module CreateFromUser
   extend ActiveSupport::Concern
 
   included do
-    attr_accessor :from
+    attr_accessor :from, :name
 
     def from=(email)
-
       unless email.blank?
 
         # search using the same method as Devise validation
@@ -29,7 +28,6 @@ module CreateFromUser
 
         unless from_user
           from_user = User.where(email: email).first_or_create
-
           unless from_user
             errors.add(:from, :invalid)
           end
@@ -37,12 +35,21 @@ module CreateFromUser
 
         self.user = from_user
       end
-
     end
 
     def from
-      user.email unless user.nil?
+      # TODO: Use "user&.email" as Ruby 2.2 has reached EOL on 2018-03-31?
+      user.email if user
     end
+
+    def name=(name)
+      self.user.update_attribute(:name, name) unless name.blank?
+    end
+
+    def name
+      user.name if user
+    end
+
   end
 
 end

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -24,6 +24,8 @@
 
       <%= f.check_box :ticket_creation_is_open_to_the_world %>
 
+      <%= f.check_box :ask_for_name %>
+
       <h5><%= t(:notification_settings) %></h5>
 
       <%= f.check_box :first_reply_ignores_notified_agents %>

--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -9,6 +9,12 @@
     <%= f.text_field :from, tabindex: tabindex %>
   </p>
 
+  <% if Tenant.current_tenant.ask_for_name %>
+    <p>
+      <%= f.text_field :name, tabindex: tabindex %>
+    </p>
+  <% end %>
+
   <% if !current_user.nil? && current_user.agent? %>
     <p>
       <% blank = @email_addresses.count == 0 ? EmailAddress.default_email : nil %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -308,6 +308,7 @@ de:
 
       ticket:
         from: E-Mail Adresse Absender
+        name: Name
         subject: Betreff
         content: Inhalt
         status: Status
@@ -430,3 +431,4 @@ de:
         notify_user_when_account_is_created: Benutzer benachrichtigen nachdem das Benutzerkonto erstellt wurde.
         stylesheet_url: Pfad zu eigenem Stylesheet.
         ticket_creation_is_open_to_the_world: Jeder ist berechtigt, Tickets zu erstellen.
+        ask_for_name: Auf Formularen zum Erstellen von Tickets nach dem Namen fragen.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -307,6 +307,7 @@ en:
 
       ticket:
         from: From email address
+        name: Name
         subject: Subject
         content: Content
         status: Status
@@ -429,3 +430,4 @@ en:
         notify_user_when_account_is_created: Notify user when account is created.
         stylesheet_url: Add the path to your own custom stylesheet.
         ticket_creation_is_open_to_the_world: Tickets creation is open to everybody.
+        ask_for_name: Ask for name on new ticket forms.

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -307,6 +307,7 @@ fr-CA:
 
       ticket:
         from: De l'adresse courriel
+        name: Nom
         subject: Sujet
         content: Objet
         status: Statut
@@ -429,3 +430,4 @@ fr-CA:
         notify_user_when_account_is_created: Notifier l'utilisateur après avoir créé son compte utilisateur.
         stylesheet_url: Ajouter chemin pour feuille de style personalisée.
         ticket_creation_is_open_to_the_world: Création de billets autorisée à tout le monde.
+        ask_for_name: Demander pour le nom sur les formulaires pour créer un billet.

--- a/config/locales/fr-FR.yml
+++ b/config/locales/fr-FR.yml
@@ -307,6 +307,7 @@ fr-FR:
 
       ticket:
         from: De l'adresse courriel
+        name: Nom
         subject: Sujet
         content: Objet
         status: Statut
@@ -429,3 +430,4 @@ fr-FR:
         notify_user_when_account_is_created: Notifier l'utilisateur après avoir créé son compte utilisateur.
         stylesheet_url: Ajouter chemin pour feuille de style personalisée.
         ticket_creation_is_open_to_the_world: Création de tickets autorisée à tout le monde.
+        ask_for_name: Demander pour le nom sur les formulaires pour créer un ticket.

--- a/db/migrate/20181011140158_add_ask_for_name_to_tenants.rb
+++ b/db/migrate/20181011140158_add_ask_for_name_to_tenants.rb
@@ -1,0 +1,7 @@
+class AddAskForNameToTenants < ActiveRecord::Migration[5.1]
+  def change
+    unless column_exists? :tenants, :ask_for_name
+      add_column :tenants, :ask_for_name, :boolean, default: false, nil: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171016140901) do
+ActiveRecord::Schema.define(version: 20181011140158) do
 
   create_table "attachments", force: :cascade do |t|
     t.integer "attachable_id"
@@ -147,6 +147,8 @@ ActiveRecord::Schema.define(version: 20171016140901) do
     t.integer "email_template_id"
     t.boolean "ticket_creation_is_open_to_the_world", default: true
     t.string "stylesheet_url"
+    t.string "javascript_url"
+    t.boolean "ask_for_name", default: false
     t.index ["domain"], name: "index_tenants_on_domain", unique: true
     t.index ["email_template_id"], name: "index_tenants_on_email_template_id"
   end

--- a/test/controllers/tickets_controller_test.rb
+++ b/test/controllers/tickets_controller_test.rb
@@ -136,6 +136,32 @@ class TicketsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should render name input for new tickets if told so by tenant settings' do
+    sign_in users(:alice)
+    Tenant.current_domain = tenants(:main).domain
+    Tenant.current_tenant.ask_for_name = true
+    Tenant.current_tenant.save!
+    assert_match %r(<input[^>]+ticket\[name\]), get(:new).body
+    Tenant.current_tenant.ask_for_name = false
+    Tenant.current_tenant.save!
+    refute_match %r(<input[^>]+ticket\[name\]), get(:new).body
+  end
+
+  test 'should write email and name to user' do
+    sign_in users(:alice)
+    post :create, params: {
+      ticket: {
+        from: 'test@test.nl',
+        name: 'Tester',
+        content: 'Foobar',
+        subject: 'Foobar',
+      }
+    }
+    user = Ticket.last.user
+    assert_equal user.email, 'test@test.nl'
+    assert_equal user.name, 'Tester'
+  end
+
   # BEGIN OF TESTS FOR TICKET CREATION
   # SITUATIONS:
   # 1) CAPTCHA / NO CAPTCHA


### PR DESCRIPTION
For new tickets created by email and in order to keep the new tickets forms short, setting the user name to what's in front of the email-@ is very nice.

However, for those who heavily rely on new ticket forms and would like to have the real user names, this new tenant setting will come in handy:

Tick the checkbox next to "ask for name on new ticket forms" and users may enter their real name when submitting a new ticket by use of the forms.

---

<img width="514" alt="screen shot 2018-10-11 at 20 21 21" src="https://user-images.githubusercontent.com/7255/46825648-736a4b80-cd94-11e8-8028-a1cbbb65d855.png">

---

<img width="783" alt="screen shot 2018-10-11 at 20 21 39" src="https://user-images.githubusercontent.com/7255/46825665-7bc28680-cd94-11e8-8c5b-533ad5bfa666.png">
