### PR TITLE
Localize captcha

### DIFF
--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -74,7 +74,7 @@
 
   <% if Ticket.recaptcha_keys_present? && !user_signed_in? %>
     <p>
-      <%= recaptcha_tags %>
+      <%= recaptcha_tags hl: I18n.locale %>
     </p>
   <% end %>
 


### PR DESCRIPTION
Very small PR to pass the current `I18n.locale` to the captcha. Instead of the EN default "I'm not a robot", you will get for instance:

<img width="754" alt="screen shot 2018-10-12 at 15 01 55" src="https://user-images.githubusercontent.com/7255/46870812-f987a000-ce2f-11e8-8299-da1e9e003431.png">

(Please ignore the red warning, I made the screenshot off my localhost development.)