### PR TITLE
RTL and styling roots

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -66,6 +66,10 @@ table thead tr th{
 
 /* --- Uncategorized --- */
 
+.user-signed-in {
+  background: #30363e;
+}
+
 .label{
 	text-transform: uppercase;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,10 +78,6 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    if I18n.locale == :fa
-      @rtl = true
-    else
-      @rtl = false
-    end
+    @rtl = %i(ar fa).include?(I18n.locale)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     <%= csrf_meta_tags %>
   </head>
 
-  <body style="<%= 'direction:rtl;' if [:ar].include?(I18n.locale)%> <%= 'background: #30363e' if user_signed_in? %>">
+  <body style="<%= 'direction:rtl;' if @rtl %> <%= 'background: #30363e' if user_signed_in? %>">
 
     <% if user_signed_in? %>
       <nav class="top-bar" data-topbar>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     <%= csrf_meta_tags %>
   </head>
 
-  <body style="<%= 'direction:rtl;' if @rtl %> <%= 'background: #30363e' if user_signed_in? %>">
+  <body class="<%= ["#{controller_name}-#{action_name}", ('user-signed-in' if user_signed_in?)].compact.join(',') %>" style="<%= 'direction: rtl' if @rtl %>">
 
     <% if user_signed_in? %>
       <nav class="top-bar" data-topbar>


### PR DESCRIPTION
Two little commits:

* Fix a bug in RTL handling
* Add controller/action and sign in status classes to the body tag

To explain the latter, here's a copy from the commit message:

>To restyle different parts of the application with a custom stylesheet, it's necessary to have elements to root your custom styles to.
>
>This commit adds the two classes to the body tag:
>* <controller_name>-<action_name> (e.g. "tickets-new")
>* "user-signed-in" if a use has previously authenticated himself
>
>Say, you want to include the public new tickets form into another website by use of an iframe, you can match the styling by rooting your custom styles to "body.tickets-new:not(.user-signed-in)".

