### PR TITLE
Fix name= when ticket validation fails

### DIFF
--- a/app/models/concerns/create_from_user.rb
+++ b/app/models/concerns/create_from_user.rb
@@ -43,7 +43,7 @@ module CreateFromUser
     end
 
     def name=(name)
-      self.user.update_attribute(:name, name) unless name.blank?
+      self.user.update_attribute(:name, name) if user && !name.blank?
     end
 
     def name


### PR DESCRIPTION
When submitting an invalid new ticket form, no associated user is initialized and therefore the attempt to set "name" kaboomed.

Sorry, this one slipped under my radar.