### PR TITLE
Fix hook route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Brimir::Application.routes.draw do
     resource :lock, only: [:destroy, :create], module: :tickets
   end
 
-  get "/:hook/:mail_key/tickets",
+  post "/:hook/:mail_key/tickets",
     controller: 'tickets',
     action: 'create',
     constraints: ->(r) { r.path_parameters[:hook].in? TicketsController::MAIL_HOOKS },


### PR DESCRIPTION
I'm really sorry, this one is a little embarrassing: I've changed the mail hook route from POST to GET in order to try something locally. However, forgot to add a TODO to remind me of switching it back before committing.

This commit sets it back to the way it should be: POST.