### PR TITLE
Gracefully fall back from potential Paperclip thumbnail creation

### DIFF
--- a/app/mailers/ticket_mailer.rb
+++ b/app/mailers/ticket_mailer.rb
@@ -153,8 +153,18 @@ class TicketMailer < ActionMailer::Base
           content_id = attachment.content_id[1..-2]
           content_id = nil unless incoming.content.include?(content_id)
         end
-        incoming.attachments.create(file: file,
-            content_id: content_id)
+
+        attachment = incoming.attachments.new
+        attachment.content_id = content_id
+        begin
+          attachment.file = file
+          attachment.save!
+        rescue
+          file.rewind
+          attachment.disable_thumbnail_generation = true
+          attachment.file = file
+          attachment.save!
+        end
       end
 
     end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -35,7 +35,11 @@ class Attachment < ApplicationRecord
   do_not_validate_attachment_file_type :file
   before_post_process :thumbnail?
 
+  attr_accessor :disable_thumbnail_generation
+
   def thumbnail?
+
+    return false if disable_thumbnail_generation
 
     unless file_content_type.nil?
 

--- a/app/views/attachments/_attachment.html.erb
+++ b/app/views/attachments/_attachment.html.erb
@@ -1,8 +1,7 @@
 <li>
-  <% if attachment.thumbnail? %>
+  <% if attachment.thumbnail? && attachment.file.exists?(:thumb) %>
     <a href="<%= attachment.file.url %>" class="fancybox" rel="gallery-<%= attachment.attachable.id %>"><img src="<%= attachment.file.url(:thumb) %>" /></a>
   <% end %>
   <strong><%= attachment.file_file_name %></strong>
   <span class="meta"><%= number_to_human_size(attachment.file.size) %> &middot; <%= link_to t(:download), attachment.file.url %></span>
 </li>
-


### PR DESCRIPTION
We've had a few issues recently when Paperclip has failed to create attachments for incoming emails due to a number of issues. These appear to be centred around the way it creates thumbnails, and potential issues with ImageMagick/Ghostscript.

The changes proposed here try to gracefully fall back from creating an attachment if thumbnail generation fails, so that the email is still received but without the thumbnail.

This issue may go away if the application is switched to Active Storage when it is upgraded to Rails 5.2.